### PR TITLE
Adding parameters for the enrollment signal receivers

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1350,6 +1350,7 @@ class CourseEnrollment(models.Model):
                 course_key=self.course_id,
                 mode=self.mode,
                 countdown=SCORE_RECALCULATION_DELAY_ON_ENROLLMENT_UPDATE,
+                course_enrollment=self,
             )
 
     def send_signal(self, event, cost=None, currency=None):

--- a/common/djangoapps/student/signals/signals.py
+++ b/common/djangoapps/student/signals/signals.py
@@ -5,7 +5,7 @@ Enrollment track related signals.
 
 from django.dispatch import Signal
 
-ENROLLMENT_TRACK_UPDATED = Signal(providing_args=['user', 'course_key', 'mode', 'countdown'])
+ENROLLMENT_TRACK_UPDATED = Signal(providing_args=['user', 'course_key', 'mode', 'countdown', 'course_enrollment'])
 UNENROLL_DONE = Signal(providing_args=["course_enrollment", "skip_refund"])
 ENROLL_STATUS_CHANGE = Signal(providing_args=["event", "user", "course_id", "mode", "cost", "currency"])
 REFUND_ORDER = Signal(providing_args=["course_enrollment"])


### PR DESCRIPTION
This PR adds 'course_enrollment' object so  'ENROLLMENT_TRACK_UPDATED' signal receivers can have extra context.  