### PR TITLE
PAE-279 - Change edx-sga for a custom version.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -83,7 +83,6 @@ edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search
-edx-sga
 edx-submissions
 edx-user-state-client
 edx-when

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,7 +113,7 @@ edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proc
 edx-rbac==1.2.1           # via edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==1.3.4         # via -r requirements/edx/base.in
-edx-sga==0.11.0           # via -r requirements/edx/base.in
+git+https://github.com/Pearson-Advance/edx-sga.git@v0.11.2#egg=edx-sga==0.11.2
 edx-submissions==3.1.7    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -126,7 +126,7 @@ edx-proctoring==2.4.0     # via -r requirements/edx/testing.txt, edx-proctoring-
 edx-rbac==1.2.1           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==1.3.4         # via -r requirements/edx/testing.txt
-edx-sga==0.11.0           # via -r requirements/edx/testing.txt
+git+https://github.com/Pearson-Advance/edx-sga.git@v0.11.2#egg=edx-sga==0.11.2
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.1.7    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -99,3 +99,4 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xbloc
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf
+git+https://github.com/Pearson-Advance/edx-sga.git@v0.11.2#egg=edx-sga==0.11.2


### PR DESCRIPTION
## Background

This PR: https://github.com/edx/edx-platform/pull/22171 changed the edx-sga version, but since we use a custom version, we need to pin the edx-sga to the GitHub repository instead of using the PyPi version.

We could add this custom requirement to the customer-data and remove edx-sga from the platform, but all devstacks will not have SGA installed by default, so that's why it was decided to pin the custom version directly to the platform.

## Description:

This PR changes the edx-sga version to a custom version.

## Note:

"make upgrade" was not used because it generated requirement issues.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 