### PR TITLE
MIGRATION - Add support for extended profile fields name mapping

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -246,6 +246,10 @@ def _get_extended_profile_fields():
         "specialty": _(u"Specialty")
     }
 
+    field_labels_map.update(
+        configuration_helpers.get_value('extended_profile_fields_name_mapping', {}),
+    )
+
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:
         if field_to_exclude in extended_profile_field_names:


### PR DESCRIPTION
**Description:**

This PR adds support for field name mapping to the extended profile fields.
Now you can set the display name of the fields using a site configuration setting called: extended_profile_fields_name_mapping
e.g.

```json
"extended_profile_fields_name_mapping":{
    "my_extended_profile_field": "My extended profile field display name."
}
```

**Previous work:**

[PR](https://github.com/proversity-org/edx-platform/pull/1121)
