### PR TITLE
PAE-124 - Exclude main course staff members from gradebook.

### DIFF
--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -12,10 +12,12 @@ from django.urls import reverse
 from django.views.decorators.cache import cache_control
 from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
+from lms.djangoapps.ccx.utils import exclude_master_course_staff_users
+from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.instructor.views.api import require_course_permission
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore
 
 from .. import permissions
@@ -77,6 +79,12 @@ def get_grade_book_page(request, course, course_key):
         courseenrollment__course_id=course_key,
         courseenrollment__is_active=1
     ).order_by('username').select_related("profile")
+
+    if configuration_helpers.get_value('HIDE_MASTER_COURSE_STAFF_FROM_GRADEBOOK', False):
+        enrolled_students = exclude_master_course_staff_users(
+            users=enrolled_students,
+            course_key=course_key,
+        )
 
     total_students = enrolled_students.count()
     page = calculate_page_info(current_offset, total_students)


### PR DESCRIPTION
## Description:

This PR migrates the PAE-124 feature intended to exclude main course staff users from the gradebook page.

## Previous work:

https://github.com/proversity-org/edx-platform/pull/1132
https://github.com/proversity-org/edx-platform/pull/1134

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 
