### PR TITLE
PAE-125 - Excluding main course staff users from student management list.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -142,10 +142,19 @@ def dashboard(request, course, ccx=None):
         schedule = get_ccx_schedule(course, ccx)
         grading_policy = get_override_for_ccx(
             ccx, course, 'grading_policy', course.grading_policy)
+        enrolled_students = CourseEnrollment.objects.filter(course_id=ccx_locator, is_active=True)
         context['schedule'] = json.dumps(schedule, indent=4)
         context['save_url'] = reverse(
             'save_ccx', kwargs={'course_id': ccx_locator})
-        context['ccx_members'] = CourseEnrollment.objects.filter(course_id=ccx_locator, is_active=True)
+        context['ccx_members'] = (
+            enrolled_students
+            if not configuration_helpers.get_value('HIDE_MASTER_COURSE_STAFF_FROM_STUDENT_LIST', False)
+            else exclude_master_course_staff_users(
+                users=enrolled_students,
+                course_key=ccx_locator,
+                model='CourseEnrollment',
+            )
+        )
         context['gradebook_url'] = reverse(
             'ccx_gradebook', kwargs={'course_id': ccx_locator})
         context['grades_csv_url'] = reverse(


### PR DESCRIPTION
## Description:

This PR migrates the PAE-125 feature intended to exclude main course staff users from the CCX student management list.

## Previous work:

https://github.com/proversity-org/edx-platform/pull/1135

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 
