### PR TITLE
PAE-142 - Filter master course staff members from the profile report.

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -235,6 +235,14 @@ def enrolled_students_features(course_key, features):
         courseenrollment__is_active=1,
     ).order_by('username').select_related('profile')
 
+    if configuration_helpers.get_value('HIDE_MASTER_COURSE_STAFF_FROM_PROFILE_REPORT', False):
+        # Avoid circular import.
+        from lms.djangoapps.instructor.views.gradebook_api import exclude_master_course_staff_users
+        students = exclude_master_course_staff_users(
+            users=students,
+            course_key=course_key,
+        )
+
     if include_cohort_column:
         students = students.prefetch_related('course_groups')
 


### PR DESCRIPTION
## Description:

This PR migrates the PAE-142 feature intended to exclude main course staff users from the profile report.

## Previous work:

https://github.com/proversity-org/edx-platform/pull/1137

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 
