### PR TITLE
JP-1 - Making the account activation email site aware.

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -7,6 +7,7 @@ import logging
 
 from celery.exceptions import MaxRetriesExceededError
 from celery.task import task
+from crum import get_current_request
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -37,7 +38,15 @@ def send_activation_email(self, msg_string, from_address=None):
 
     dest_addr = msg.recipient.email_address
 
-    site = Site.objects.get_current()
+    # This approach only works with the Pearson-Core's asynchronous site context feature.
+    try:
+        site = get_current_request().site
+
+        if not site:
+            site = Site.objects.get_current()
+    except AttributeError:
+        site = Site.objects.get_current()
+
     user = User.objects.get(username=msg.recipient.username)
 
     try:


### PR DESCRIPTION
## Background:

The account activation email is sent via Celery tasks; Celery worker is not aware of the site, therefore the email templates are not overwritten and the account activation email is sent using the edx-platform template.

## Description:

This PR takes advantage of the Pearson-Core's asynchronous site context feature to make the account activation email site aware.

## Notes:

Pearson-Core must be installed in order to use this approach. If Pearson-Core is not installed, the platform will use the usual email template.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera  