### PR TITLE
PAE-351 - Allow multiple CCX courses per coach.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -28,6 +28,7 @@ from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params,
 from lms.djangoapps.instructor.views.api import _split_input_list
 from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment, CourseEnrollmentException
 from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole
 
@@ -487,3 +488,24 @@ def exclude_master_course_staff_users(users, course_key, model='User'):
         )
 
     return users
+
+
+def multiple_ccx_per_coach(course):
+    """
+    Return if the feature to allows coaches to have multiple CCX
+    courses for the same main course is enabled for the site and the course.
+
+    This feature must be enabled at site-level and course-level.
+
+    Args:
+        Course: Course object.
+    Returns:
+        True or False.
+    """
+    return (
+        course.other_course_settings.get('allow_multiple_ccx_per_coach', False)
+        and configuration_helpers.get_value(
+            'ALLOW_MULTIPLE_CCX_PER_COACH',
+            False,
+        )
+    )

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -47,7 +47,8 @@ from lms.djangoapps.ccx.utils import (
     get_ccx_for_coach,
     get_date,
     get_enrollment_action_and_identifiers,
-    parse_date
+    multiple_ccx_per_coach,
+    parse_date,
 )
 from lms.djangoapps.courseware.field_overrides import disable_overrides
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -120,7 +121,10 @@ def dashboard(request, course, ccx=None):
     """
     # right now, we can only have one ccx per user and course
     # so, if no ccx is passed in, we can sefely redirect to that
-    if ccx is None:
+    # Enabling multiple CCXs per coach will prevent the CCX coach
+    # from being redirected to the CCX course and will instead see
+    # the create CCX course view.
+    if ccx is None and not multiple_ccx_per_coach(course):
         ccx = get_ccx_for_coach(course, request.user)
         if ccx:
             url = reverse(


### PR DESCRIPTION
## Description:

This PR adds a feature to allow multiple CCX courses per coach for the same main course. The feature must be enabled at site-level and course-level. If the feature is enabled, it will prevent CCX coaches from being redirected to the CCX course and instead will show the Create CCX Course view to allow the CCX coach to create another CCX for the same main course.

## Configuration:

Site-level:
"ALLOW_MULTIPLE_CCX_PER_COACH": true

Course-level:
"allow_multiple_ccx_per_coach": true
This setting must be added as an item to the "other course settings" list.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 