### PR TITLE
PAE-351 - Enabling multiple CCXs per coach for all CCX courses.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -503,7 +503,7 @@ def multiple_ccx_per_coach(course):
         True or False.
     """
     return (
-        course.other_course_settings.get('allow_multiple_ccx_per_coach', False)
+        course.enable_ccx
         and configuration_helpers.get_value(
             'ALLOW_MULTIPLE_CCX_PER_COACH',
             False,


### PR DESCRIPTION
## Description:

This PR changes the behaviour of https://github.com/Pearson-Advance/edx-platform/pull/19 to allow all courses CCX-enabled courses to use the feature to allow multiple CCX course per coach. This PR removes the course-level setting but keeps the site-level setting.

## Configuration:

Site-level:
"ALLOW_MULTIPLE_CCX_PER_COACH": true

CCX must be enabled in the course to use this feature.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 