### PR TITLE
Pearson/PAE-424 - Shell course enrollment via instructor dashboard.

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -120,7 +120,8 @@ def get_user_email_language(user):
     return UserPreference.get_value(user, LANGUAGE_KEY)
 
 
-def enroll_email(course_id, student_email, auto_enroll=False, email_students=False, email_params=None, language=None):
+def enroll_email(course_id, student_email, auto_enroll=False, email_students=False, verified=None, email_params=None,
+                 language=None):
     """
     Enroll a student by email.
 
@@ -128,6 +129,8 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     `auto_enroll` determines what is put in CourseEnrollmentAllowed.auto_enroll
         if auto_enroll is set, then when the email registers, they will be
         enrolled in the course automatically.
+    `verified` determines if the enrollment is in verified mode only if its value
+        is provided.
     `email_students` determines if student should be notified of action by email.
     `email_params` parameters used while parsing email templates (a `dict`).
     `language` is the language used to render the email.
@@ -152,6 +155,9 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
 
         if previous_state.enrollment:
             course_mode = previous_state.mode
+
+        if verified:
+            course_mode = 'verified'
 
         enrollment_obj = CourseEnrollment.enroll_by_email(student_email, course_id, course_mode)
         if email_students:

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -632,6 +632,9 @@ def students_update_enrollment(request, course_id):
     - auto_enroll is a boolean (defaults to false)
         If auto_enroll is false, students will be allowed to enroll.
         If auto_enroll is true, students will be enrolled as soon as they register.
+    - verified is a boolean (defaults to false)
+        If verified is false, student(s) will be enrolled in audit mode
+        If verified is true, student(s) will be enrolled in verified mode
     - email_students is a boolean (defaults to false)
         If email_students is true, students will be sent email notification
         If email_students is false, students will not be sent email notification
@@ -663,6 +666,7 @@ def students_update_enrollment(request, course_id):
     identifiers_raw = request.POST.get('identifiers')
     identifiers = _split_input_list(identifiers_raw)
     auto_enroll = _get_boolean_param(request, 'auto_enroll')
+    verified = _get_boolean_param(request, 'verified')
     email_students = _get_boolean_param(request, 'email_students')
     reason = request.POST.get('reason')
     role = request.POST.get('role')
@@ -706,7 +710,7 @@ def students_update_enrollment(request, course_id):
             validate_email(email)  # Raises ValidationError if invalid
             if action == 'enroll':
                 before, after, enrollment_obj = enroll_email(
-                    course_id, email, auto_enroll, email_students, email_params, language=language
+                    course_id, email, auto_enroll, email_students, verified, email_params, language=language
                 )
                 before_enrollment = before.to_dict()['enrollment']
                 before_user_registered = before.to_dict()['user']

--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -596,6 +596,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$role = this.$container.find("select[name='role']");
             this.$enrollment_button = this.$container.find('.enrollment-button');
             this.$reason_field = this.$container.find("textarea[name='reason-field']");
+            this.$checkbox_verified = this.$container.find("input[name='verified']");
             this.$checkbox_autoenroll = this.$container.find("input[name='auto-enroll']");
             this.$checkbox_emailstudents = this.$container.find("input[name='email-students']");
             this.checkbox_emailstudents_initialstate = this.$checkbox_emailstudents.is(':checked');
@@ -615,6 +616,7 @@ such that the value can be defined later than this assignment (file load order).
                 emailStudents = batchEnroll.$checkbox_emailstudents.is(':checked');
                 sendData = {
                     action: $(event.target).data('action'),
+                    verified: batchEnroll.$checkbox_verified.is(':checked'),
                     identifiers: batchEnroll.$identifier_input.val(),
                     role: batchEnroll.$role.val(),
                     auto_enroll: batchEnroll.$checkbox_autoenroll.is(':checked'),

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -34,6 +34,12 @@ from openedx.core.djangolib.markup import HTML, Text
     %endif
     <div class="enroll-option">
         <label class="has-hint">
+            <input type="checkbox" name="verified" id="verified" aria-describedby="heading-batch-enrollment">
+            <span class="label-text">${_("Verified")}</span>
+        </label>
+    </div>
+    <div class="enroll-option">
+        <label class="has-hint">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="heading-batch-enrollment">
             <span class="label-text">${_("Auto Enroll")}</span>
             <div class="hint auto-enroll-hint">


### PR DESCRIPTION
**Description:**

This PR adds a new functionality allowing verified course enrollments from instructor Dashboard mentioned in this ticket [PAE-424](https://pearsonadvance.atlassian.net/browse/PAE-424?atlOrigin=eyJpIjoiMDYwNGQ3YTM1MTE3NGE2YWFmOTFkOTgyNjhhODZiZDMiLCJwIjoiaiJ9) . Changes are reflected in the front-end and the back-end

**Reviewers:**

- [ ] @diegomillan
