### PR TITLE
Add site configuration flag to allow changing redirection after login

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -234,8 +234,8 @@ def get_next_url_for_login_page(request):
     /account/finish_auth/ view following login, which will take care of auto-enrollment in
     the specified course.
 
-    Otherwise, we go to the `next` param or to the dashboard if nothing else is
-    specified.
+    Otherwise, we go to the ?next= query param or the configured custom
+    redirection url (the default behaviour is to go to /dashboard).
 
     If THIRD_PARTY_AUTH_HINT is set, then `tpa_hint=<hint>` is added as a query parameter.
 
@@ -249,9 +249,25 @@ def get_next_url_for_login_page(request):
         request_is_https=request.is_secure(),
     )
     if not redirect_to:
-        try:
-            redirect_to = reverse('dashboard')
-        except NoReverseMatch:
+        if settings.ROOT_URLCONF == 'lms.urls':
+            login_redirect_url = configuration_helpers.get_value('DEFAULT_REDIRECT_AFTER_LOGIN')
+
+            if login_redirect_url:
+                try:
+                    redirect_to = reverse(login_redirect_url)
+                except NoReverseMatch:
+                    log.warning(
+                        u'Default redirect after login doesn\'t exist: %(login_redirect_url)r. '
+                        u'Check the value set on DEFAULT_REDIRECT_AFTER_LOGIN configuration variable.',
+                        {"login_redirect_url": login_redirect_url}
+                    )
+
+            # If redirect url isn't set, reverse to dashboard
+            if not redirect_to:
+                # Tries reversing the LMS dashboard if the url doesn't exist
+                redirect_to = reverse('dashboard')
+
+        elif settings.ROOT_URLCONF == 'cms.urls':
             redirect_to = reverse('home')
 
     if any(param in request_params for param in POST_AUTH_PARAMS):


### PR DESCRIPTION
Description
---------------
This PR adds a setting that enables customizing the default redirect behaviour from the login page. Currently, after login, the user is redirected to /dashboard.

Change from: [#21333](https://github.com/edx/edx-platform/pull/21333)

