### PR TITLE
PAE-547 - Adding a verification for skipping email validation when SKIP_EMAIL_V…

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -388,7 +388,10 @@ def _skip_activation_email(user, running_pipeline, third_party_provider):
         )
 
     return (
-        settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) or
+        configuration_helpers.get_value(
+            'SKIP_EMAIL_VALIDATION',
+            settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None)
+        ) or
         settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') or
         (third_party_provider and third_party_provider.skip_email_verification and valid_email)
     )


### PR DESCRIPTION
### Description

This PR adds a validation for SKIP_EMAIL_VALIDATION in order to allow skipping email validation for sites that has this flag turned on.

### Reviewers

- [ ] @diegomillan 