### PR TITLE
PAE-476.1 - Rename the "export_olx" artefact directory.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/export_olx.py
@@ -99,8 +99,7 @@ def export_course_to_directory(course_key, root_dir):
     # We represent the first four with \w.
     # TODO: Once we support courses with unicode characters, we will need to revisit this.
     replacement_char = u'-'
-    course_dir = replacement_char.join([course.id.org, course.id.course, course.id.run])
-    course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir)
+    course_dir = course.url_name
 
     export_course_to_xml(store, None, course.id, root_dir, course_dir)
 


### PR DESCRIPTION
## Background:

We are currently using the "export_olx" command through edx-analytics-exporter. This "export_olx" command performs the same steps as the course export function in Studio. For some reason that will be explained later, the course export function in Studio worked and "export_olx" did not. After some debugging time, we found out what the problem was.

In short, the problem was related to the folder where the OLX artefacts are stored.

When the course export function is invoked in Studio, it will eventually get here: https://github.com/Pearson-Advance/edx-platform/blob/pearson-release/juniper.stage/cms/djangoapps/contentstore/tasks.py#L273 that function will call "export_course_to_xml" which is in charge of starting the export process. 

When the "export_olx" command is called, it will eventually get here: https://github.com/Pearson-Advance/edx-platform/blob/pearson-release/juniper.stage/cms/djangoapps/contentstore/management/commands/export_olx.py#L91 that function will call "export_course_to_xml".

Both calls have been made in the same way with some different parameters, let's focus on the "root_dir" and "course_dir" parameters. Both calls pass a mkdtemp() instance to "root_dir", this will then create a folder in /tmp/tmp_id/. Now Studio's course export function passes the result of `course_module.url_name` which will return "course" and the "export_olx" command passes `course_dir = replacement_char.join([course.id.org, course.id.course, course.id.run])
 course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir)` which will return a value in form of: ORG_COURSE_RUN.

To export video transcript files, it's necessary to call this function: https://github.com/edx/edx-val/blob/1.3.4/edxval/api.py#L958 that function calls: create_transcript_file and pass `combine(u'course', static_dir)` to "static_dir". This will result in an `fs.errors.ResourceNotFound` because it's trying to create the transcript file in /tmp/tmp_id/course/static and the course export artefacts are being created in /tmp/tmp_id/ORG_COURSE_RUN/static.

## Description: 

This PR replaces the "course_dir" argument to be the same argument as the Studio course export function to avoid crashing when creating video transcript files.

## Note:

This was only tested on a Juniper instance.

## Reviewers:

- [ ] @diegomillan 
- [ ] @ivanvgh 
- [ ] @luismorenolopera 