### PR TITLE
PAE-467-1 - User fullname generation on IES authentication.

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -881,7 +881,7 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
             'https://iam.pearson.com:443/auth/saml-idp-uid',
         ]
 
-        if (not details.get('fullname') and details.get('first_name') and details.get('last_name') and
+        if (details.get('first_name') and details.get('last_name') and
             current_provider.entity_id in ies_entity_ids):
             fullname_value = '{} {}'.format(details.get('first_name'), details.get('last_name'))
             changed['fullname'] = fullname_value


### PR DESCRIPTION
### Description:
This PR adds a logic in 'user_details_force_sync' pipeline step to generate the full name only for IES IDP.
More context can be found in[ this ticket](https://pearsonadvance.atlassian.net/browse/PAE-467?atlOrigin=eyJpIjoiYWExNWZlZjExYmYzNGU3MWE0YmM2NGYyYWEwMzk2NjQiLCJwIjoiaiJ9).

**Note**. This decision was taken since IES IDP will not provide the fullname attribute.
Also we must configure the IDP's fullname attribute map in this page '/admin/third_party_auth/samlproviderconfig/' like the image below. 
- Full Name Attribute -> 'leave it empty'
- Default Value for Full Name -> 'insert any value. **Do not leave empty**'

### Reviewers:

- [x]  @diegomillan
- [ ] @Squirrel18 
- [ ] @luismorenolopera 


x
![Screenshot from 2021-03-25 11-46-44](https://user-images.githubusercontent.com/36037715/112510991-fe224380-8d5f-11eb-92f6-8dad5bffcff6.png)
