### PR TITLE
PAE-342 - Replacing email templates to avoid issues related to Mako & Django template loaders.

### DIFF
--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -18,51 +18,44 @@
     </tr>
 {% endif %}
     <tr>
-        <td>
-            <h1>
-                {% trans "Account Activation" as header_msg %}{{ header_msg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}You're almost there! Use the link below to activate your account to access engaging, high-quality {{ platform_name }} courses. Note that you will not be able to log back into your account until you have activated it.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Activate Your Account{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-        </td>
-    </tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans trimmed asvar assist_msg %}
-                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ support_email }}{end_anchor}.
-                {% endblocktrans %}
-                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
-                <br />
-            </p>
-        </td>
-    <tr>
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
 
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% trans "You're Nearly Signed Up" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}To validate your new account, please click on the Validate Account button below.{% endblocktrans %}
+                    <br />
+                </p>
+
+                {% trans "Validate Account" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
+            </div>
+        </td>
     </tr>
     <tr>
         <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}This email message was automatically sent by {{ lms_url }} because someone attempted to create an account on {{ platform_name }} using this email address.{% endblocktrans %}
-                {% endfilter %}
+            <p>
+                {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/common/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.html
@@ -5,40 +5,41 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% trans "Create Password" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}We've restored access to your {{ platform_name }} account using the recovery email you provided at registration.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Once you've created a password [below], you will be able to log in to {{ platform_name }} with this email ({{ email }}) and your new password.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." as tmsg %}{{ tmsg | force_escape }}
-                <br />
-            </p>
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% trans "Create Password" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ site_name }}. If you didn't request this change, you can disregard this email - we have not yet created your password.{% endblocktrans %}
+                    <br />
+                </p>
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Create Password{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+                 {% trans "Create my Password" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
+
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+
+            </div>
         </td>
     </tr>
 </table>

--- a/common/templates/student/edx_ace/emailchange/email/body.html
+++ b/common/templates/student/edx_ace/emailchange/email/body.html
@@ -5,29 +5,51 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% trans "Email Change" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Confirm Email Change{% endblocktrans %}
-            {% endfilter %}
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png"" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% trans "Email Change" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                     {% if is_secondary_email_change_request %}
+                    {% blocktrans %}We received a request to change the secondary e-mail associated with your {{ site_name }} account to {{ new_email }}. If this is correct, please click below to confirm your new secondary e-mail address. {% endblocktrans %}
+                {% else %}
+                    {% blocktrans %}We received a request to change the e-mail associated with your {{ site_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please click below to confirm your new e-mail address.{% endblocktrans %}
+                {% endif %}
+                    <br />
+                </p>
+
+                 {% trans "Confirm Email Change" as course_cta_text %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ platform_name }} web site.{% endblocktrans %}
-                {% endfilter %}
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p>
+                 {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ site_name }} web site.{% endblocktrans %}
                 <br />
             </p>
-
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -5,57 +5,55 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% filter force_escape %}
-                {% blocktrans %}Welcome to {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
-            </h1>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}To get started, please visit https://{{ site_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}The login information for your account follows:{% endblocktrans %}
-                {% endfilter %}
-                <br />
-                {% filter force_escape %}
-                {% blocktrans %}email: {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-                {% filter force_escape %}
-                {% blocktrans %}password: {{ password }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}It is recommended that you change your password.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% blocktrans %}
+                    Welcome to {{ course_name }}
+                    {% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}To get started, please visit https://{{ site_name }}.{% endblocktrans %}
+                    <br />
+                </p>
 
-            <p style="color: rgba(0,0,0,.75);">
-              <a href="{{ course_url }}">
-                {% filter force_escape %}
-                {% blocktrans %}You may access your course.{% endblocktrans %}
-                {% endfilter %}
-              </a>
-                <br />
-            </p>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}The login information for your account follows:{% endblocktrans %}
+                    <br />
+                    {% blocktrans %}email: {{ email_address }}{% endblocktrans %}
+                    <br />
+                    {% blocktrans %}password: {{ password }}{% endblocktrans %}
+                    <br />
+                </p>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Sincerely yours, The {{ course_name }} Team{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+                    {% blocktrans %}It is recommended that you change your password.{% endblocktrans %}
+                    <br />
+                </p>
+            </div>
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -5,62 +5,57 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% filter force_escape %}
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
+
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
                 {% blocktrans %}
                     You have been invited to be a beta tester for {{ course_name }} at {{ site_name }}
                 {% endblocktrans %}
-                {% endfilter %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}The invitation has been sent by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            {% if auto_enroll %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To start accessing course materials, please visit:{% endblocktrans %}
-                    {% endfilter %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}The invitation has been sent by a member of the course staff. To start accessing course materials, please click the button below.{% endblocktrans %}
                     <br />
                 </p>
+
+                 {% trans "View Course" as course_cta_text %}
+            {% if auto_enroll %}
 
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=display_name|default:course.display_name_with_default course_cta_url=course_url %}
-            {% elif course_about_url is not None %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To enroll in this course and begin the beta test:{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-                {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Visit {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
 
+            {% elif course_about_url is not None %}
+                {% blocktrans asvar course_cta_text %}Visit {{ course_name }}{% endblocktrans %}
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_about_url %}
             {% else %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To enroll in this course and begin the beta test:{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-                {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Visit {{ site_name }}
-                {% endblocktrans %}
-                {%endfilter%}
-
+                {% blocktrans asvar course_cta_text %}Visit {{ site_name }}{% endblocktrans %}
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
             {% endif %}
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p>
+                {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -5,32 +5,55 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% filter force_escape %}
-                {% blocktrans %}You have been invited to {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
-            </h1>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% filter force_escape %}
+                    {% blocktrans %}You have been invited to {{ course_name }}{% endblocktrans %}
+                    {% endfilter %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% filter force_escape %}
+                    {% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
+                    {% endfilter %}
+                    <br />
+                </p>
 
         {% if is_shib_course %}
             {% if auto_enroll %}
-                <p style="color: rgba(0,0,0,.75);">
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
                     {% filter force_escape %}
-                    {% blocktrans %}To access this course click on the button below and login:{% endblocktrans %}
+                    {% blocktrans %}To access this course click on the button below and log in.{% endblocktrans %}
                     {% endfilter %}
                     <br />
                 </p>
 
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_url %}
             {% elif course_about_url is not None %}
-                <p style="color: rgba(0,0,0,.75);">
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
                     {% filter force_escape %}
                     {% blocktrans %}To access this course visit it and register:{% endblocktrans %}
                     {% endfilter %}
@@ -40,9 +63,11 @@
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
             {% endif %}
         {% else %}
-            <p style="color: rgba(0,0,0,.75);">
+            <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
                 {% filter force_escape %}
-                {% blocktrans %}Please finish your registration and fill out the registration form making sure to use {{ email_address }} in the Email field:{% endblocktrans %}
+                {% blocktrans %}Please finish your registration and fill out the registration form, making sure to use {{ email_address }} in the Email field:{% endblocktrans %}
                 {% endfilter %}
                 <br />
             </p>
@@ -50,7 +75,9 @@
             {% trans "Finish Your Registration" as button_cta_text %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=button_cta_text course_cta_url=registration_url %}
 
-            <p style="color: rgba(0,0,0,.75);">
+            <p style="padding: 0px;
+                        width: 50%;
+                        min-width: 300px;">
                 {% if auto_enroll %}
                     {% filter force_escape %}
                     {% blocktrans %}Once you have registered and activated your account, you will see {{ course_name }} listed on your dashboard.{% endblocktrans %}
@@ -68,12 +95,8 @@
                 <br />
             </p>
         {% endif %}
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+
+            </div>
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -4,34 +4,42 @@
 {% load static %}
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+   <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
+
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                     {% blocktrans %}You have been unenrolled{% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard. Your other courses have not been affected. {% endblocktrans %}
+                    <br />
+                </p>
+            </div>
+        </td>
+    </tr>
     <tr>
         <td>
-            <h1>
-                {% filter force_escape %}
-                {% blocktrans %}
-                    You have been unenrolled from {{ course_name }}
-                {% endblocktrans %}
-                {% endfilter %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Your other courses have not been affected.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
-                {% endfilter %}
+            <p>
+                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -7,29 +7,61 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
                 {% blocktrans %}
-                    You have been enrolled in {{ course_name }}
+
                 {% endblocktrans %}
-                {% endfilter %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endfilter %}
                 <br />
             </p>
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Access the Course Materials Now{% endblocktrans %}
-            {% endfilter %}
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
+                <br />
+            </p>
+        </td>
+    </tr>
+   <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
+
+<img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                     You have been enrolled in {{ course_name }}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
+                    <br />
+                </p>
+
+           {% trans "Access the Course Materials Now" as course_cta_text %}
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
-                {% endfilter %}
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p>
+                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -4,39 +4,43 @@
 {% load static %}
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+   <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
+
+<img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                     {% blocktrans %}You have been removed as a beta tester{% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff. This course will remain on your dashboard, but you will no longer be part of the beta testing group. Your other courses have not been affected. {% endblocktrans %}
+                    <br />
+                </p>
+
+            </div>
+        </td>
+    </tr>
     <tr>
         <td>
-            <h1>
-                {% filter force_escape %}
-                {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}{% endblocktrans %}
-                {% endfilter %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Your other courses have not been affected.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
+            <p>
+                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load ace %}
+{% load static %}
 
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
@@ -62,8 +63,8 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="https://media.sailthru.com/595/1k1/8/o/599f355101b3f.png" width="70"
-                                    height="30" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                                    src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/logo.png" width="40"
+                                    height="40" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
                             <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -14,19 +14,21 @@
         {% endif %}
     {% endif %}
     style="
-        color: #ffffff;
+        padding: 15px 20px;
+        margin: 50px 0px;
+        font-family: 'Open Sans', sans-serif;
+        background-color: #FFB81C;
+        font-size: 18px;
+        border: 2px solid #505759;
+        border-radius: 5px;
+        -webkit-border-radius: 5px;
+        -moz-border-radius: 5px;
         text-decoration: none;
-        border-radius: 4px;
-        -webkit-border-radius: 4px;
-        -moz-border-radius: 4px;
-        background-color: #005686;
-        border-top: 12px solid #005686;
-        border-bottom: 12px solid #005686;
-        border-right: 50px solid #005686;
-        border-left: 50px solid #005686;
         display: inline-block;
+        color: #000000;
+
     ">
-        {# old email clients require the use of the font tag :( #}
-        <font color="#ffffff"><b>{{ course_cta_text }}</b></font>
+    {# old email clients require the use of the font tag :( #}
+        <font color="#000000;"><b>{{ course_cta_text }}</b></font>
     </a>
 </p>

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -1,59 +1,65 @@
 {% extends 'ace_common/edx_ace/common/base_body.html' %}
-
 {% load i18n %}
 {% load static %}
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% trans "Password Reset" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            border: 1px solid #F3F3F3;">
 
-            {% if failed %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
+            <img src="https://mylearningx.pearson.com/static/pearson-pols-theme/images/PearsonLogo_Primary_Blk_RGB.png" style="width: 150px; padding: 5px;" />
+
+            <div style="width: 90%;
+                        background-color: #D4EAE4;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-image: url('https://mylearningx.pearson.com/static/pearson-pols-theme/images/laptop_transparent-bg.png');
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% trans "Password Reset" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+                </p>
+
+
+                {% if failed %}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
                     {% blocktrans %}However, there is currently no user account associated with your email address: {{ email_address }}.{% endblocktrans %}
-                    {% endfilter %}
                     <br />
                 </p>
 
-                <p style="color: rgba(0,0,0,.75);">
-                    {% trans "If you did not request this change, you can ignore this email." as tmsg %}{{ tmsg | force_escape }}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% trans "If you did not request this change, you can ignore this email." %}
                     <br />
                 </p>
             {% else %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." as tmsg %}{{ tmsg | force_escape }}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;">
+                    {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
                     <br />
                 </p>
-                {# xss-lint: disable=django-trans-missing-escape #}
-                {% trans "Change my Password" as course_cta_text %}
 
-                {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
-                <a href="{{ reset_link }}" style="
-                    color: #ffffff;
-                    text-decoration: none;
-                    border-radius: 4px;
-                    -webkit-border-radius: 4px;
-                    -moz-border-radius: 4px;
-                    background-color: #005686;
-                    border-top: 12px solid #005686;
-                    border-bottom: 12px solid #005686;
-                    border-right: 50px solid #005686;
-                    border-left: 50px solid #005686;
-                    display: inline-block;
-                ">
-                    {# old email clients require the use of the font tag :( #}
-                    <font color="#ffffff"><b>{{ course_cta_text }}</b></font>
-                </a>
-            {% endif %}
+                 {% trans "Change my Password" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+                 {% endif %}
+
+            </div>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
## Background:

In summary, we are currently experiencing some issues related to the Mako & Django template loaders and this leads to template issues when sending emails from different sites.

More information on this issue can be found here: https://pearsonadvance.atlassian.net/browse/PAE-342

## Description:

This PR replaces some of the current email templates in favour of the Pearson-brand templates.

Emails should have this Pearson-branded layout:

![image](https://user-images.githubusercontent.com/17520199/112915486-fcd87a00-90c3-11eb-84fe-e594628be9f4.png)

## Reviewers:

- [ ] @diegomillan 