### PR TITLE
Adding Github Workflows

### DIFF
--- a/.github/workflows/assign_by_path.yml
+++ b/.github/workflows/assign_by_path.yml
@@ -22,6 +22,6 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          teams: "DevOps"
+          teams: "Pearson-Advance/devops"
           include-draft: false
           skip-with-manual-reviewers: 4

--- a/.github/workflows/assign_by_path.yml
+++ b/.github/workflows/assign_by_path.yml
@@ -1,0 +1,27 @@
+name: assign_by_path
+
+on:
+  pull_request:
+    branches:
+      - 'pearson-release/*.master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Assign by path
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '**/migrations/*'
+      
+      - name: Auto Assign DevOps if exist migrations changes
+        uses: rowi1de/auto-assign-review-teams@v1.0.1
+        if: steps.changes.outputs.src == 'true'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          teams: "DevOps"
+          include-draft: false
+          skip-with-manual-reviewers: 4

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -1,0 +1,22 @@
+name: dev deployment
+
+on:
+  push:
+    branches:
+      - 'pearson-release/*.stage'
+
+jobs:
+  build-production:
+    environment: dev
+    name: Build Dev deployment
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build jenkins jobs
+      uses: Mondtic/build-jenkins-job@v1.0.0
+      with:
+        jenkins-url: ${{ secrets.JENKINS_URL }}
+        jenkins-token: ${{ secrets.JENKINS_TOKEN }}
+        jenkins-user: ${{ secrets.JENKINS_USER }}
+        jenkins-job: ${{ secrets.JENKINS_JOB }}
+        jenkins-job-params: '{"default_parameters": true}'
+        jenkins-wait-job: 'wait'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: labeler
+
+on:
+  pull_request:
+    branches:
+      - 'pearson-release/*.master'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: CodelyTV/pr-size-labeler@v1.6.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'true'
+          message_if_xl: >
+            'This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.’
+          github_api_url: 'api.github.com'

--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -1,0 +1,22 @@
+name: production deployment
+
+on:
+  push:
+    branches:
+      - 'pearson-release/*.master'
+
+jobs:
+  build-production:
+    environment: production
+    name: Build Production deployment
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build jenkins jobs
+      uses: Mondtic/build-jenkins-job@v1.0.0
+      with:
+        jenkins-url: ${{ secrets.JENKINS_URL }}
+        jenkins-token: ${{ secrets.JENKINS_TOKEN }}
+        jenkins-user: ${{ secrets.JENKINS_USER }}
+        jenkins-job: ${{ secrets.JENKINS_JOB }}
+        jenkins-job-params: '{"default_parameters": true}'
+        jenkins-wait-job: 'no-wait'


### PR DESCRIPTION
Adding GitHub workflows with:

labeler actions: to define a size for each PR using a label.
assign by path: to add a DevOps reviewer when the PR has migrations changes.
deployments: to run the Jenkins jobs using Jenkins API.