### PR TITLE
PAE-628 - Change the behavior of ENROLLMENT_TRACK_UPDATED signal

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1337,9 +1337,10 @@ class CourseEnrollment(models.Model):
                 self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED)
                 self.send_signal(EnrollStatusChange.unenroll)
 
-        if mode_changed:
+        if mode_changed or settings.get('TRACK_ALL_ENROLLMENT', False):
             # Only emit mode change events when the user's enrollment
             # mode has changed from its previous setting
+            # or TRACK_ALL_ENROLLMENT is enabled
             self.emit_event(EVENT_NAME_ENROLLMENT_MODE_CHANGED)
             # this signal is meant to trigger a score recalculation celery task,
             # `countdown` is added to celery task as delay so that cohort is duly updated
@@ -1471,7 +1472,7 @@ class CourseEnrollment(models.Model):
                     user.username,
                 )
                 raise CourseFullError
-        if cls.is_enrolled(user, course_key):
+        if cls.is_enrolled(user, course_key) and not settings.get('TRACK_ALL_ENROLLMENT', False):
             log.warning(
                 u"User %s attempted to enroll in %s, but they were already enrolled",
                 user.username,


### PR DESCRIPTION
Description
---------------

Course enrollment signal can always be called if TRACK_ALL_ENROLLMENT is enabled.

**Ticket:** [PAE-628](https://pearsonadvance.atlassian.net/browse/PAE-628)