### PR TITLE
fix: udpate dependencies

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,7 +181,7 @@ pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.in
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/base.in
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -218,7 +218,7 @@ pkgconfig==1.5.1          # via -r requirements/edx/testing.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/testing.txt
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/testing.txt
 py==1.8.1                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -209,7 +209,7 @@ pkgconfig==1.5.1          # via -r requirements/edx/base.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.txt
+git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2             # via -r requirements/edx/base.txt
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client


### PR DESCRIPTION
This is to fix the issue when we run a deployment in a new instance.

"ERROR: Could not find a version that satisfies the requirement py2neo==3.1.2"