### PR TITLE
PAE-467 - User fullname generation on IES authentication. 

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -875,6 +875,19 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
                 changed[provider_field] = current_value
                 setattr(model, field, provider_value)
 
+        # Generate fullname only for IES IDP.
+        ies_entity_ids = [
+            'https://iam-stage.pearson.com:443/auth/saml-idp-uid',
+            'https://iam.pearson.com:443/auth/saml-idp-uid',
+        ]
+
+        if (details.get('first_name') and details.get('last_name') and
+            current_provider.entity_id in ies_entity_ids):
+            fullname_value = '{} {}'.format(details.get('first_name'), details.get('last_name'))
+            changed['fullname'] = fullname_value
+
+            setattr(user.profile, 'name', fullname_value)
+
         if changed:
             logger.info(
                 u'[THIRD_PARTY_AUTH] User performed SSO and data was synchronized. '


### PR DESCRIPTION
### Description:
This PR adds a logic in 'user_details_force_sync' pipeline step to generate the full name in case it is not provided by IES IDP.
More context can be found in [ this ticket](https://pearsonadvance.atlassian.net/browse/PAE-467?atlOrigin=eyJpIjoiYWExNWZlZjExYmYzNGU3MWE0YmM2NGYyYWEwMzk2NjQiLCJwIjoiaiJ9).

**Note**. This decision was taken since IES IDP will not provide the fullname attribute.
Also we must configure the IDP's fullname attribute map in this page '/admin/third_party_auth/samlproviderconfig/' like the image below. 
- Full Name Attribute -> 'leave it empty'
- Default Value for Full Name -> 'insert any value. **Do not leave empty**'