### PR TITLE
Pearson/PAE-628-fb - Change ENROLLMENT_TRACK_UPDATED to site configuration

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1336,10 +1336,10 @@ class CourseEnrollment(models.Model):
                 UNENROLL_DONE.send(sender=None, course_enrollment=self, skip_refund=skip_refund)
                 self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED)
                 self.send_signal(EnrollStatusChange.unenroll)
-
-        if mode_changed:
+        if mode_changed or configuration_helpers.get_value('TRACK_ALL_ENROLLMENT', False):
             # Only emit mode change events when the user's enrollment
             # mode has changed from its previous setting
+            # or TRACK_ALL_ENROLLMENT is enabled
             self.emit_event(EVENT_NAME_ENROLLMENT_MODE_CHANGED)
             # this signal is meant to trigger a score recalculation celery task,
             # `countdown` is added to celery task as delay so that cohort is duly updated
@@ -1471,7 +1471,7 @@ class CourseEnrollment(models.Model):
                     user.username,
                 )
                 raise CourseFullError
-        if cls.is_enrolled(user, course_key):
+        if cls.is_enrolled(user, course_key) and not configuration_helpers.get_value('TRACK_ALL_ENROLLMENT', False):
             log.warning(
                 u"User %s attempted to enroll in %s, but they were already enrolled",
                 user.username,

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -934,6 +934,9 @@ MAINTENANCE_BANNER_TEXT = ENV_TOKENS.get('MAINTENANCE_BANNER_TEXT', None)
 ########################## limiting dashboard courses ######################
 DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 
+########################## signal track all course enrollment ######################
+TRACK_ALL_ENROLLMENT = ENV_TOKENS.get('TRACK_ALL_ENROLLMENT', False)
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded


### PR DESCRIPTION
### Description:
Add TRACK_ALL_ENROLLMENT to site configuration.
The course enrollment signal can always be called if TRACK_ALL_ENROLLMENT is enabled.