### PR TITLE
PAE-103 Enhancement: change in default behavior of studio_home.enable_global_staff_optimization

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -509,7 +509,7 @@ def course_listing(request):
     org_names_list = []
 
     if optimization_enabled:
-        org = request.GET.get('org', '')
+        org = request.GET.get('org') if request.GET.get('org') else None
         org_names_list = [(org['short_name']) for org in get_organizations() if 'short_name' in org]
 
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)


### PR DESCRIPTION
The Waffle Switch` studio_home.enable_global_staff_optimization` was created initially because when too many courses were created, the Studio home raised a timeout error. However, right now the amount of courses is not a concern. 

Explanation: 
  Preconditions:
    - When org is None, all courses are fetched. 
    - When someone clicks on All organizations, a org='' is sent in the request.

This line `org = request.GET.get('org') if request.GET.get('org') else None` ensures that:
 + When org == None, initially, returns all courses.
 + When All organizations is selected, therefore org = '' in request, the if statement evaluates False, org = None and all courses are returned.
 + When an org is selected, lets say 'PX', org = 'PX'.