### PR TITLE
PAE-845 Enhance prerequisites to allow more flexible configuration

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1161,7 +1161,7 @@ def settings_handler(request, course_key_string):
                         if not all(is_valid_course_key(course_key) for course_key in prerequisite_course_keys):
                             return JsonResponseBadRequest({"error": _("Invalid prerequisite course key")})
                         set_prerequisite_courses(course_key, prerequisite_course_keys)
-                        # add all courses with same org and number to milestones.
+                        # Add all courses with same org and number to milestones
                         PREREQUISITE_NOT_MET = 0
                         run_extension_point(
                             'PEARSON_CORE_MILESTONE_PREREQUISITES_MODULE',

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -803,16 +803,15 @@ def student_dashboard(request):
         enrollment.course_id for enrollment in course_enrollments
         if enrollment.course_overview.pre_requisite_courses
     )
-
     courses_requirements_not_met = get_pre_requisite_courses_not_completed(user, courses_having_prerequisites)
 
-    # sort requirements for each course in course_requirements_not_met.
+    # Sort requirements for each course in course_requirements_not_met
     courses_requirements_not_met = run_extension_point(
         'PEARSON_CORE_SORT_ENROLLED_PREREQUISITES',
         user=user,
         courses_requirements_not_met=courses_requirements_not_met,
     )
-    # get the sku value for the requirements of each course in courses_requirements_not_met.
+    # Get the SKU value for the requirements of each course in courses_requirements_not_met
     skus_not_enrollment_in_requirements = run_extension_point(
         'PEARSON_CORE_STUDENT_NOT_ENROLLED_IN_REQUIREMENTS',
         user=user,

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -953,17 +953,17 @@ def course_about(request, course_id):
 
         is_shib_course = uses_shib(course)
 
-        # get prerequisite courses display names
+        # Get prerequisite courses display names
         pre_requisite_courses = get_prerequisite_courses_display(course)
 
         courses_requirements_not_met = get_pre_requisite_courses_not_completed(request.user, frozenset({course.id}))
-        # sort requirements for each course in course_requirements_not_met.
+        # Sort requirements for each course in course_requirements_not_met
         skus_not_enrollment_in_requirements = run_extension_point(
             'PEARSON_CORE_STUDENT_NOT_ENROLLED_IN_REQUIREMENTS',
             user=request.user,
             courses_requirements_not_met=courses_requirements_not_met,
         )
-        # the first prerequisite from courses_requirements_not_met is taken.
+        # Dictionary with the first requirement in course_requirements_not_met
         course_requirements = run_extension_point(
             'PEARSON_CORE_STUDENT_COURSE_REQUIREMENTS_FOR_COURSEWARE',
             courses_requirements_not_met=courses_requirements_not_met,
@@ -1008,9 +1008,9 @@ def course_about(request, course_id):
             # context. This value is therefor explicitly set to render the appropriate header.
             'disable_courseware_header': True,
             'pre_requisite_courses': pre_requisite_courses,
-            'course_requirements': course_requirements if course_requirements else None,
+            'course_requirements': course_requirements,
             'student_not_enrollment_in_requirement': \
-                skus_not_enrollment_in_requirements.get(course.id) if skus_not_enrollment_in_requirements else None,
+                skus_not_enrollment_in_requirements.get(course.id),
             "ecommerce_payment_page": EcommerceService().payment_page_url(),
             'course_image_urls': overview.image_urls,
             'reviews_fragment_view': reviews_fragment_view,


### PR DESCRIPTION
## This PR is on hold down due to business decisions

Currently prerequisites operate at the course run level, and only one course run can be specified.  Which means that course run dependencies are very inflexible. From the example below a learner could pass course-v1:PS+INTRODA+OCT but if course-v1:PS+DATAVIZ+NOV has a prerequisite of course-v1:PS+INTRODA+NOV then the learner could not proceed with the DATAVIZ course even though they passed an earlier run of INTRODA.

PS+INTRODA:

 - course-v1:PS+INTRODA+Oct
 - course-v1:PS+INTRODA+Nov
 - course-v1:PS+INTRODA+Dec

PS+DATAVIZ (dependent on completion of a run of PS+INTRODA):

 - course-v1:PS+DATAVIZ+Oct
 - course-v1:PS+DATAVIZ+Nov
 - course-v1:PS+DATAVIZ+Dec

Ideally, the PS+DATAVIZ runs would be unlocked if a learner had completed any of the PS+INTRODA runs.

It's neccesary to enable `'MILESTONES_APP':True `  and `'ENABLE_PREREQUISITE_COURSES': True`.  Also it's neccesary pull the PR https://github.com/Pearson-Advance/pearson-core/pull/25 from pearson_core, then `run_extension_point()` in used in the edx-platform.

For this, when a prerequisite is selected in studio, It is added to the milestones_milestone table through the `course.py` module, which in this PR now adds the courses with the same org and number taken from discovery through the `course_uuid`.

 - Select the prerequisite course: 

![Selection_085](https://user-images.githubusercontent.com/30726391/137954888-056ea8af-e327-443c-99fb-fe3fcf137859.png)

 - Add the courses with same org and number in milestones_milestone table:

![Selection_086](https://user-images.githubusercontent.com/30726391/137955466-d190ddc4-b141-44d4-8423-0bd1196bd193.png)

For a user to enter the course, the prerequisite must be certified and this is added to a table called milestones_usermilestone, for this the function handle_course_cert_awarded is modified in `lms/djangoapps/certificates/models.py`

![Selection_089](https://user-images.githubusercontent.com/30726391/137998887-07dc016d-b2af-4ed1-aa7d-31ad55e51fc1.png)

Also, to improve the learner experience, Following the logic:

![Selection_150](https://user-images.githubusercontent.com/30726391/142876283-741e05f7-5201-4c50-8b0b-21ea8546fc30.png)

For this, add backend functionality to sort courses_requirements_not_met variable if the learner is enrolled and  if the learnor is not enrolled find the sku for verified mode of the course requirement, to redirect the link: 

![Selection_154](https://user-images.githubusercontent.com/30726391/142887986-9898aea8-8db9-44df-b709-9894f4d9db9f.png)

About course if the learner is enrolled and basket sku if the learner is not enrolled, to show this in the frontend it's neccesary follow the PR https://github.com/Pearson-Advance/openedx-themes/pull/189 from openedx-themes.

IMPORTANT: To active this functionality for an organization it's necessary to add it in CUSTOM_PREREQUISITES_FOR_ORG in site configurations, both in the lms and in the studio. For example: "CUSTOM_PREREQUISITES_FOR_ORG":["PX"] and enable the Feature Flag ENABLE_CUSTOM_PREREQUISITES.

![Selection_176](https://user-images.githubusercontent.com/30726391/143142332-024bc1bc-f66d-4c47-8fb5-57747dd12738.png)

Also in the course about view for the course with prerequisites the links have the same behavior of the learner dashboard, that means,  About course if the learner is enrolled and basket sku if the learner is not enrolled.

![Selection_182](https://user-images.githubusercontent.com/30726391/144088615-17eb97d0-31f7-42bd-ac68-66d84e0804b1.png)