### PR TITLE
PADV-19-fix: Change the feature flag name to enable license limits feature.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -258,7 +258,7 @@ def create_ccx(request, course, ccx=None):
         log.info(u'Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
 
     # Adding an extension point to create the institution_ccx for PearsonVUE.
-    if configuration_helpers.get_value('PCO_ENFORCE_LICENSE_LIMITS', False):
+    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False):
         run_extension_point(
             'PCO_CREATE_INSTITUTION_CCX_INSTANCE',
             ccx_id=ccx_id,


### PR DESCRIPTION
### Description:
This PR changes the feature flag to match the same variable name in [PADV-12](https://github.com/Pearson-Advance/edx-platform/pull/57) to switch on the license limits enforcement.