### PR TITLE
PADV-26 - Add license usage url to the data report context.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -48,6 +48,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import available_divi
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
 from openedx.core.djangolib.markup import HTML, Text
@@ -720,6 +721,18 @@ def _section_data_download(course, access):
         ),
         'export_ora2_data_url': reverse('export_ora2_data', kwargs={'course_id': six.text_type(course_key)}),
     }
+
+    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False):
+        get_license_usage_url, is_master_course = run_extension_point(
+            'PCO_GET_LICENSE_USAGE_URL',
+            course_id=course_key,
+        )
+
+        section_data.update({
+            'get_license_usage_url': get_license_usage_url,
+            'is_master_course': is_master_course,
+        })
+
     if not access.get('data_researcher'):
         section_data['is_hidden'] = True
     return section_data

--- a/lms/static/js/instructor_dashboard/data_download.js
+++ b/lms/static/js/instructor_dashboard/data_download.js
@@ -97,6 +97,7 @@
             this.ddc = new DataDownloadCertificate(this.$section.find('.issued_certificates'));
             this.$list_studs_btn = this.$section.find("input[name='list-profiles']");
             this.$list_studs_csv_btn = this.$section.find("input[name='list-profiles-csv']");
+            this.$license_usage_csv_btn = this.$section.find("input[name='license-usage-csv']");
             this.$proctored_exam_csv_btn = this.$section.find("input[name='proctored-exam-results-report']");
             this.$survey_results_csv_btn = this.$section.find("input[name='survey-results-report']");
             this.$list_may_enroll_csv_btn = this.$section.find("input[name='list-may-enroll-csv']");
@@ -195,6 +196,28 @@
                             display: 'block'
                         });
                     }
+                });
+            });
+            this.$license_usage_csv_btn.click(function() {
+                var errorMessage = gettext('Error generating license usage report. Please try again.');
+                dataDownloadObj.clear_display();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: dataDownloadObj.$license_usage_csv_btn.data('endpoint'),
+                    error: function(error) {
+                        errorMessage = error.responseText ? JSON.parse(error.responseText) : errorMessage;
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
+                            display: 'block',
+                        });
+                    },
+                    success: function(data) {
+                        dataDownloadObj.$reports_request_response.text(data.status);
+                        return $('.msg-confirm').css({
+                            display: 'block',
+                        });
+                    },
                 });
             });
             this.$list_studs_btn.click(function() {


### PR DESCRIPTION
### Description:
This PR adds the license usage URL with the course_id  to the data download section context, so when rendering the template the new button (Download license usage) will have the URL to trigger the action.

More context about the new button in [PADV-26 in openedx-themes](https://github.com/Pearson-Advance/openedx-themes/pull/186).

More context about the view that will have the logic in [PADV-26 course_operations plugin](https://github.com/Pearson-Advance/course_operations/pull/20).

**Note:** This feature is only for **_pearson-vue-theme_** and when the `PCO_ENABLE_LICENSE_ENFORCEMENT` flag is active in the site settings.