### PR TITLE
feat: override openedx-language-preference cookie domain.

### DIFF
--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -32,11 +32,15 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 """
                 Wrapper function for set_cookie() which applies SESSION_COOKIE_DOMAIN override
                 """
-
+                language_cookie_domain = configuration_helpers.get_value('LANGUAGE_COOKIE_DOMAIN')
                 # only override if we are setting the cookie name to be the one the Django Session Middleware uses
                 # as defined in settings.SESSION_COOKIE_NAME
                 if key == configuration_helpers.get_value('SESSION_COOKIE_NAME', settings.SESSION_COOKIE_NAME):
                     domain = session_cookie_domain
+
+                # Override the domain when the cookie is the LANGUAGE_COOKIE.
+                elif key == settings.LANGUAGE_COOKIE and language_cookie_domain:
+                    domain = language_cookie_domain
 
                 kwargs = {
                     'max_age': max_age,

--- a/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
@@ -75,6 +75,7 @@ class SessionCookieDomainSiteConfigurationOverrideTests(TestCase):
             site=self.site,
             site_values={
                 "SESSION_COOKIE_DOMAIN": self.site.domain,
+                "LANGUAGE_COOKIE_DOMAIN": "fake.domain",
             }
         )
         self.client = Client()
@@ -86,3 +87,4 @@ class SessionCookieDomainSiteConfigurationOverrideTests(TestCase):
         """
         response = self.client.get('/', HTTP_HOST=self.site.domain)
         self.assertIn(self.site.domain, str(response.cookies['sessionid']))
+        self.assertIn("fake.domain", str(response.cookies['openedx-language-preference']))


### PR DESCRIPTION
## Description:

This PR adds the feature which allows us to override the `LANGUAGE_COOKIE` domain based on the **new-custom**`LANGUAGE_COOKIE_DOMAIN` site configuration. The main goal here is to allow eCommerce to consume this cookie.

The idea of doing so is to set a wider domain for `openedx-language-preference` cookie, in order it can be consumed cross-site within our main domain. Currently, the domain is the specific site, Let's see an example regarding the `LANGUAGE_COOKIE` which we are interested in:

If you are in http://lms.main.localhost:18000 and you change the site language using the language selector, then the `openedx-language-preference` cookie is set with `lms.main.localhost` as domain.

![image](https://user-images.githubusercontent.com/40271196/168009759-5e676f0d-d0e5-4c61-b5a8-715819edfd9d.png)

Even though this is the expected behavior, the way this is handled does not allow us to share the cookie to another subdomain. That's why this change overrides the domain making it wider. Therefore, it can be consume by eCommerce.


## Testing Instructions:

1. **Basic Setup**: Create a course and its seat within eCommerce _(I added the course as Verified and Audit)_.
2. **Language Setup**:  configure the site configuration variables such as `released_languages`, `SHOW_HEADER_LANGUAGE_SELECTOR` and make sure you have added the same languages as `released_languages`  in http://lms.main.localhost:18000/admin/dark_lang/darklangconfig/
3. **Cookie Domain Setup**: Add `"SESSION_COOKIE_DOMAIN":".main.localhost"` and `"LANGUAGE_COOKIE_DOMAIN": ".main.localhost" `to site configuration.
4. **eComm Setup**:  Download the branch from [eComm change](https://github.com/Pearson-Advance/ecommerce/pull/27) so you can see the effects on eComm.
5. From LMS enroll in the course.
6. Change the language.

![image](https://user-images.githubusercontent.com/40271196/168012210-00c9e203-9ef9-4969-9be3-15642d423747.png)

7. Click on the green button to upgrade to verified.
8. You are now redirected to eComm to pay for the verified track.
9. Make sure the page has some text in the language you selected previously and take a look at the `openedx-language-preference` cookie which must be present.

## Tests:
To verify the tests are still passing.
1. Enter the lms shell.
2. Run:
- $ pytest openedx/core/djangoapps/site_configuration/tests/test_middleware.py
- $ pytest openedx/core/djangoapps/site_configuration/tests/


## Note:

Since the `SessionCookieDomainOverrideMiddleware` only works when `SESSION_COOKIE_DOMAIN` is defined, then this site configurations must be defined.

Ticket: [PAE-144](https://agile-jira.pearson.com/browse/PAE-144)