### PR TITLE
VUE/PADV143 certiportlearning - privacy policy

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -22,6 +22,7 @@ from django_countries import countries
 import third_party_auth
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.helpers import FormDescription
 from openedx.core.djangolib.markup import HTML, Text
@@ -1006,6 +1007,14 @@ class RegistrationFormFactory(object):
                 terms_link=terms_link
             ),
             tos_link_end=HTML("</a>"),
+        )
+        label_with_terms_of_service_and_privacy_policy = run_extension_point(
+            'PEARSON_CORE_REGISTRATION_FORM_MODULE',
+            platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+        )
+        label = (
+            label_with_terms_of_service_and_privacy_policy
+            if label_with_terms_of_service_and_privacy_policy else label
         )
 
         # Translators: "Terms of service" is a legal document users must agree to


### PR DESCRIPTION
## Approach

This PR add `run_extension_point` for `registration_form.py` to show Privacy Policy in the message showed in Create an Account for Certiportlearning.

![Selection_174](https://user-images.githubusercontent.com/30726391/169229004-aae0a7f1-c45d-4b09-8e3e-be578a913869.png)
