### PR TITLE
PADV-142 - feat: hide the membership section from licensed CCX staff users. 

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -535,8 +535,14 @@ def _section_membership(course, access):
     ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
     enrollment_role_choices = configuration_helpers.get_value('MANUAL_ENROLLMENT_ROLE_CHOICES',
                                                               settings.MANUAL_ENROLLMENT_ROLE_CHOICES)
+    # Hide the membership tab for licensed CCXs from their staff users.
+    is_licensed_ccx = run_extension_point(
+        'PCO_IS_LICENSED_CCX',
+        course_id=course.id,
+    )
 
     section_data = {
+        'is_hidden': True if is_licensed_ccx and not access.get('admin', False) else False,
         'section_key': 'membership',
         'section_display_name': _('Membership'),
         'access': access,


### PR DESCRIPTION
## Context:

A `ccx_coach` of a Master Course, gets the `staff` role over the **CCX** the coach creates from the Master. When a user has the `staff` role, then this instructor is able to see and use the **INSTRUCTOR Tab**, therefore can enroll students within the _**membership section**_. 

![image](https://user-images.githubusercontent.com/40271196/177707750-6cd94a4a-f950-4a2a-9441-12a102b8034e.png)

The course licensing enrollment process is meant to be exclusively through the **CCX COACH Tab**, where enrollments are subject to be rejected if the license has reached its purchased seats limit. Given that the instructor has the capability to enroll users from the **INSTRUCTOR Tab**, then the license can be circumvented.

## Description.

This PR is an interim countermeasure against the license enforcement issue. The idea is to hide the _**membership section**_  from the licensed CCX staff users to avoid that the instructors are able to circumvent the license limit and are forced to use only the **CCX COACH Tab**.

The membership section shouldn't be hidden for **global admins.**.

To determine when it is necessary to hide the _**membership section**_, this change requires to execute a `run_extension_point` to call a function from the [Course Operation Plugin ](https://github.com/Pearson-Advance/course_operations).

## Testing Instruction.

1. Get your devstack up and running.
2. Make sure the PCO plugin is installed, and checkout to this [branch](https://github.com/Pearson-Advance/course_operations/tree/vue/PADV-142). Take a look at https://github.com/Pearson-Advance/course_operations/pull/101 for more information.

When the membership should be hidden.
3. Use an Admin Instructor user (CCX COACH of a licensed CCX), to create a CCX.
4. Verify that the membership section **is not** present in the Instructor tab.

When the membership shouldn't be hidden.
5. Use a global admin User.
6. Go to the created CCX during step 3.
7. Verify that the membership section **is** present in the Instructor tab.

**Ticket:** [PADV-142](https://agile-jira.pearson.com/browse/PADV-142)