### PR TITLE
PADV-158 - Add PCO_IS_USER_ALLOWED_TO_CREATE_CCX run_extension_point.

### DIFF
--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -5,6 +5,9 @@ Registers the CCX feature for the edX platform.
 
 from django.conf import settings
 from django.utils.translation import ugettext_noop
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from common.djangoapps.student.auth import is_ccx_course
 
 from student.roles import CourseCcxCoachRole
 from xmodule.tabs import CourseTab
@@ -30,6 +33,20 @@ class CcxCourseTab(CourseTab):
         if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
             return False
+
+        # Disable ccx coach tab for master courses if user is not allowed to create ccx.
+        if (
+            not is_ccx_course(course.id) and
+            # site configuration PCO_ENABLE_LICENSE_ENFORCEMENT is to control platform default.
+            configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and
+            not run_extension_point(
+                'PCO_IS_USER_ALLOWED_TO_CREATE_CCX',
+                user=user,
+                master_course=course.id,
+            )
+        ):
+            # If course licensing is enable, then regular ccxs are disabled.
+                return False
 
         if hasattr(course.id, 'ccx') and bool(user.has_perm(VIEW_CCX_COACH_DASHBOARD, course)):
             return True

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -93,6 +93,18 @@ def coach_dashboard(view):
 
         if not course.enable_ccx:
             raise Http404
+        # Disable ccx view for master courses if user is not allowed to create ccx.
+        elif (
+            not ccx and
+            # site configuration PCO_ENABLE_LICENSE_ENFORCEMENT is to control platform default.
+            configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and
+            not run_extension_point(
+                'PCO_IS_USER_ALLOWED_TO_CREATE_CCX',
+                user=request.user,
+                master_course=course.id,
+            )
+        ):
+            raise Http404
         else:
             if bool(request.user.has_perm(VIEW_CCX_COACH_DASHBOARD, course)):
                 # if user is staff or instructor then he can view ccx coach dashboard.


### PR DESCRIPTION
This PR adds the run_extension_point's for the is_institution_admin_and_license function of the course operations plugin [PADV-158 - course-operations](https://github.com/Pearson-Advance/course_operations/pull/105) which validate that both institution admin and licence exist to enable access to the ccx_coach tab.

## PR Related

### course-operations

[PADV-158 - course-operations](https://github.com/Pearson-Advance/course_operations/pull/105)

## Test this PR

To test this PR it is necessary to be in the correct branch of the related PR's and then enter
`http://localhost:18000/courses/{master_course}/ccx_coach`, do it for non-admin users and institution admins.