### PR TITLE
PADV-144 - Do not add master course staff users to CCXs.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -254,7 +254,10 @@ def create_ccx(request, course, ccx=None):
     )
 
     assign_staff_role_to_ccx(ccx_id, request.user, course.id)
-    add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
+    is_course_licensing_enable = configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False)
+
+    if not is_course_licensing_enable:
+        add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
     # using CCX object as sender here.
     responses = SignalHandler.course_published.send(
@@ -265,7 +268,7 @@ def create_ccx(request, course, ccx=None):
         log.info(u'Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
 
     # Adding an extension point to create the institution_ccx for PearsonVUE.
-    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False):
+    if is_course_licensing_enable:
         run_extension_point(
             'PCO_CREATE_INSTITUTION_CCX_INSTANCE',
             ccx_id=ccx_id,


### PR DESCRIPTION
## Description:

Once a CCX is created, then the `add_master_course_staff_to_ccx` function is called to add staff and instructor roles on ccx to all the staff and instructors members of master course. This is not convenient for Course Licensing because it is not the desired behavior. Therefore, this PR is intended to change the workflow of the ccx creation to stop the execution of `add_master_course_staff_to_ccx`. The approach taken here is also based on the result of [PADV-158](https://agile-jira.pearson.com/browse/PADV-158) where unlicensed ccx are not meant to be created if the site is using Course Licensing.

## Testing Instruction:
1. Set up: Given a Master Course under a license, for which there are at least one staff and one instructor on this master course.
2. Using an InstructorAdministrator, create a CCX from the Master Course.
3. The staff and instructor users of step 1 shouldn't get enrolled in the CCX created in step 2.