### PR TITLE
PADV-150 - feat: grant access to the CCX Coach Tab to users with staff role over ccx.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -98,6 +98,13 @@ def coach_dashboard(view):
                 # if user is staff or instructor then he can view ccx coach dashboard.
                 return view(request, course, ccx)
             else:
+                # If user has the staff role at CCX level, then he/she can view ccx coach dashboard for licensed ccxs.
+                if ccx and run_extension_point(
+                    'PCO_IS_USER_ALLOWED_TO_ACCESS_CCX_COACH_TAB',
+                    ccx_id=CCXLocator.from_course_locator(course.id, six.text_type(ccx.id)),
+                    user=request.user,
+                    ):
+                    return view(request, course, ccx)
                 # if there is a ccx, we must validate that it is the ccx for this coach
                 role = CourseCcxCoachRole(course_key)
                 if not role.has_user(request.user):


### PR DESCRIPTION
## Description:
This PR updates the current validation to allow more users than the **owner** of the CCX to see and manage the CCX COACH TAB under the condition that those users must have the `staff` role over the CCX. To accomplish this, a run_extension_point is used `PCO_IS_USER_ALLOWED_TO_ACCESS_CCX_COACH_TAB`, and the function is being added [here](https://github.com/Pearson-Advance/course_operations/pull/106).

## Testing Instructions:

To conduct the following test, we'll need to have 3 users, let's label them:

- A global admin as _**admin**_. You may use `edx@example.com`
- An institution administrator as **_Coach_**. Create a regular account and then add it trough the portal as an institution administrator for an institution with licenses.
-  A regular user as **_Invited_**. Create an account.

1. Make sure you install the plugin and the branch in this [PR](https://github.com/Pearson-Advance/course_operations/pull/106)
2. Use the **_Coach_** and from a course of any license, create a CCX. 
3. Since this user is the CCX COACH, then it is obvious the CCX COACH TAB is visible.
4. Use the _**admin**_ user and go to the CCX created in step 1.
5. Use the instructor tab and the membership tab to grant the `staff` role to the **_Invited_** users.
6. Use the **_Invited_**, and go to the CCX and verify that you can see and manage the CCX COACH TAB.

Ticket: [PADV-150](https://agile-jira.pearson.com/browse/PADV-150)