### PR TITLE
PADV-167 - Add PCO_ENABLE_COURSE_LICENSING run_extension_point to schedule all units when creating a CCX.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -237,14 +237,16 @@ def create_ccx(request, course, ccx=None):
     # Save display name explicitly
     override_field_for_ccx(ccx, course, 'display_name', name)
 
-    # Hide anything that can show up in the schedule
-    hidden = 'visible_to_staff_only'
-    for chapter in course.get_children():
-        override_field_for_ccx(ccx, chapter, hidden, True)
-        for sequential in chapter.get_children():
-            override_field_for_ccx(ccx, sequential, hidden, True)
-            for vertical in sequential.get_children():
-                override_field_for_ccx(ccx, vertical, hidden, True)
+    # if course licensing is enabled, then all units will be shown in schedule.
+    if not run_extension_point('PCO_ENABLE_COURSE_LICENSING'):
+        # Hide anything that can show up in the schedule
+        hidden = 'visible_to_staff_only'
+        for chapter in course.get_children():
+            override_field_for_ccx(ccx, chapter, hidden, True)
+            for sequential in chapter.get_children():
+                override_field_for_ccx(ccx, sequential, hidden, True)
+                for vertical in sequential.get_children():
+                    override_field_for_ccx(ccx, vertical, hidden, True)
 
     ccx_id = CCXLocator.from_course_locator(course.id, six.text_type(ccx.id))
 


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-167

## Description
 
This PR add run_extension_point validation with the setting `PCO_ENABLE_COURSE_LICENSING` to enable or disable that all units will be scheduled based upon the start date of the master course. 

Calling the run_extension_points makes sure that the plugin is installed and the site is configured, because if only the site is configured, then it is not enough to guarantee that course licensing is actaully working, because the plugin may not be installed

## Type of Change

- [x] Add validation run_extension_point to enable or disable automatically schedule all units when creating a CCX.

## Testing

- Set `'ENABLE_COURSE_LICENSING'` in site configurations.
- Create CCX from licensed Master Course.
- Enter to CCX Coach tab and thin Schedule tab.
- Verify that units have been added.

![image](https://user-images.githubusercontent.com/30726391/185731367-8adc14f3-0bb0-4ee2-a997-815b26b7353a.png)

- Remove unit and refresh ccx_coach tab and verify the units. the changes should be mantained.
- Verify learner course.

## Reviewers

- [x] @Jacatove 
- [x] @Squirrel18 