### PR TITLE
PADV-58 - Add 'PCO_GET_PENDING_ENROLLMENTS_FOR_CCX' run_extension_point to aggregate  enrollments allowed in context.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -179,6 +179,11 @@ def dashboard(request, course, ccx=None):
                 model='CourseEnrollment',
             )
         )
+        # if course licensing is enabled, pending enrollments will be in the context.
+        context['pending_ccx_members'] = run_extension_point(
+            'PCO_GET_PENDING_ENROLLMENTS_FOR_CCX',
+            ccx_id=ccx_locator,
+        ) if run_extension_point('PCO_ENABLE_COURSE_LICENSING') else []
         context['gradebook_url'] = reverse(
             'ccx_gradebook', kwargs={'course_id': ccx_locator})
         context['grades_csv_url'] = reverse(


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-58

## Description
 
Add a run_extension_point to aggregate enrollments allowed in context to get enrollments and enrollments allowed and show both enrollments and enrollments allowed in the Student List Management in the CCX coach tab.

## PR's Related

### openedx-themes

- https://github.com/Pearson-Advance/openedx-themes/pull/224

### course_operations

- https://github.com/Pearson-Advance/course_operations/pull/116

## Type of Change

- [x] Add `PCO_GET_COURSE_LICENSING_STUDENT_LIST_MANAGEMENT` run_extension_point.

## Testing

- Follow the testing instructions at https://github.com/Pearson-Advance/course_operations/pull/116

## Reviewers

- [x] @Jacatove 
- [x] @Squirrel18 