### PR TITLE
PADV-141 - feat: support feedback at enrollment section within CCX Coach Tab.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -269,11 +269,9 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
                 continue
 
             # Check the License limit in the pearson course operation plugin.
-            if (
-                    configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False)
-                    and is_ccx_course(course_key)
-                    and not must_enroll
-               ):
+            is_course_licensing_enable = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+            if is_course_licensing_enable and not must_enroll:
+
                 allow_enrollment, message = run_extension_point(
                     'PCO_ENFORCE_LICENSE_LIMITS',
                     course_key=course_key,

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -12,17 +12,21 @@ from smtplib import SMTPException
 
 import pytz
 from ccx_keys.locator import CCXLocator
+from crum import get_current_request
+from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six.moves import map
+from student.models import CourseEnrollment, CourseEnrollmentException
+from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole
 
-from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.ccx.custom_exception import CCXUserValidationException
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor.access import allow_access, list_with_level, revoke_access
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params, unenroll_email
 from lms.djangoapps.instructor.views.api import _split_input_list
@@ -30,9 +34,6 @@ from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from student.auth import is_ccx_course
-from student.models import CourseEnrollment, CourseEnrollmentException
-from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole
 
 log = logging.getLogger("edx.ccx")
 
@@ -256,6 +257,10 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
         course_locator = course_key.to_course_locator()
         staff = CourseStaffRole(course_locator).users_with_role()
         admins = CourseInstructorRole(course_locator).users_with_role()
+        is_course_licensing_enable = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
+        if is_course_licensing_enable:
+            current_request = get_current_request()
 
         for identifier in identifiers:
             must_enroll = False
@@ -268,19 +273,19 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
                 errors.append(u"{0}".format(exp))
                 continue
 
-            # Check the License limit in the pearson course operation plugin.
-            is_course_licensing_enable = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
-            if is_course_licensing_enable and not must_enroll:
-
-                allow_enrollment, message = run_extension_point(
+            if (
+                is_course_licensing_enable and
+                not must_enroll and
+                not run_extension_point(
                     'PCO_ENFORCE_LICENSE_LIMITS',
                     course_key=course_key,
+                    email=email,
+                    student=student,
+                    request=current_request,
                 )
-
-                if not allow_enrollment:
-                    log.info(message)
-                    errors.append(message)
-                    break
+            ):
+                # If License limit is reached, block enrollment.
+                break
 
             if CourseEnrollment.objects.is_course_full(ccx_course_overview) and not must_enroll:
                 error = _(u'The course is full: the limit is {max_student_enrollments_allowed}').format(


### PR DESCRIPTION
## Description:

**Note:** _This change only is applied for sites where Course Licensing is enable._

As there is no feedback when a CCX Coach enrolls someone in her CCX, the purpose of this PR is to support such feature. Therefore the following type of messages are supported with this change:

**Type - Message - Case**
1. SUCCESS - `'Student [name@mail.com] has been enrolled.'` - If user was already registered.
2. SUCCESS - `'Student [name@mail.com] has been invited.'` - If there was no user associated with the email used at enrollment.
3. FAIL (Already supported) -` License limit of {} reached. There are already {} students enrolled across all classes. Please contact Pearson Vue Support Team at {support_link}`.


## Related PRs:
As this change is required for Course Operations, then the logic behind supporting feedback messaging is implemented in the Plugin. And as the themes expects only error messages, then there is an additional modification for the theme in order to differentiate SUCCESS and FAIL messages.

**Plugin:**
- https://github.com/Pearson-Advance/course_operations/pull/118

**Themes:**
- https://github.com/Pearson-Advance/openedx-themes/pull/225

## Examples:

The success messages are shown first.
The error messages related using invalid email or non existing username are still available.

### Case 1: Mixed Cases - license limit not reached and bad emails.

The license of this CCX had 4 purchased seats and there is already one enrollment before pressing the **enroll** button for 2 invalid emails and 3 valid emails. Student52 is already an existing user and Student53, Student54 are not.

**Email used in enrollment text field:** `bademail1, bademail2,  student52@nacional.com, student53@nacional.com, student54@nacional.com`
**Result:**
![image](https://user-images.githubusercontent.com/40271196/189679901-31710222-bed2-43b2-b3e0-ef1f73f41d46.png)

### Case 2: Mixed Cases  - license limit reached with only valid emails.

The license of this CCX had 4 purchased seats and there is already one enrollment before pressing the **enroll** button for 4 valid emails. Student52 is already an existing user, Student53, Student54 and Student55 are not.

**Email used in enrollment text field:** `student52@nacional.com, student53@nacional.com, student54@nacional.com, student55@nacional.com`
**Result:**
![image](https://user-images.githubusercontent.com/40271196/189681606-fa39f18c-985a-4c38-a678-2d7574897e07.png)

### Case 3: Mixed Cases  - license limit reached and bad emails.
The license of this CCX had 4 purchased seats and there is already one enrollment before pressing the **enroll** button for 2 invalid emails and 4 valid emails. Student52 is already an existing user and Student53, Student54 and Student55 are not.

**Email used in enrollment text field:** `bademail1, bademail2,  student52@nacional.com, student53@nacional.com, student54@nacional.com, student55@nacional.com`
**Result:**
![image](https://user-images.githubusercontent.com/40271196/189682865-62770cad-ca63-48ed-8b4d-a0060e089320.png)

### Case 3: Single Failed.
If licenses is already full and the email is valid when enrolling.
![image](https://user-images.githubusercontent.com/40271196/189684751-68ccc50c-e3b2-4f7c-89d9-4473f75c2d3d.png)


### Case 4: Single Success.
When license has available seat and the email is valid when enrolling.
![image](https://user-images.githubusercontent.com/40271196/189684332-97a2cd1f-93e2-43d9-893b-39f5de48128b.png)

## Testing Instructions:

**Note:** _This change is only applied for sites where Course Licensing is enable._

1. Checkout to this branch for edx-platform.
2. Checkout to this branch for themes: https://github.com/Pearson-Advance/openedx-themes/pull/225
3. Checkout to thin branch for course operations plugin: https://github.com/Pearson-Advance/course_operations/pull/118
5. Use an Institution Administrator to create a CCX for which there are available seats.
6. Enroll and check the messages.
