### PR TITLE
PADV-191 - Use PCO_ENABLE_COURSE_LICENSING run_extension_point instead PCO_ENABLE_LICENSE_ENFORCEMENT site configuration.

### DIFF
--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -6,7 +6,6 @@ Registers the CCX feature for the edX platform.
 from django.conf import settings
 from django.utils.translation import ugettext_noop
 from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from common.djangoapps.student.auth import is_ccx_course
 
 from student.roles import CourseCcxCoachRole
@@ -34,11 +33,12 @@ class CcxCourseTab(CourseTab):
             # If ccx is not enable do not show ccx coach tab.
             return False
 
-        # Disable ccx coach tab for master courses if user is not allowed to create ccx.
+        # If Course Licensing is enable, disable CCXCoach tab for master courses if user is not allowed to create ccx.
+        is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
         if (
             not is_ccx_course(course.id) and
-            # site configuration PCO_ENABLE_LICENSE_ENFORCEMENT is to control platform default.
-            configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and
+            is_course_licensing_enabled and
             not run_extension_point(
                 'PCO_IS_USER_ALLOWED_TO_CREATE_CCX',
                 user=user,

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -257,9 +257,10 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
         course_locator = course_key.to_course_locator()
         staff = CourseStaffRole(course_locator).users_with_role()
         admins = CourseInstructorRole(course_locator).users_with_role()
-        is_course_licensing_enable = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+        is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
 
-        if is_course_licensing_enable:
+        # If Course Licensing is enabled, current request is obtained.
+        if is_course_licensing_enabled:
             current_request = get_current_request()
 
         for identifier in identifiers:
@@ -274,7 +275,7 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
                 continue
 
             if (
-                is_course_licensing_enable and
+                is_course_licensing_enabled and
                 not must_enroll and
                 not run_extension_point(
                     'PCO_ENFORCE_LICENSE_LIMITS',

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -80,6 +80,8 @@ def coach_dashboard(view):
         """
         course_key = CourseKey.from_string(course_id)
         ccx = None
+        is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
         if isinstance(course_key, CCXLocator):
             ccx_id = course_key.ccx
             try:
@@ -93,11 +95,10 @@ def coach_dashboard(view):
 
         if not course.enable_ccx:
             raise Http404
-        # Disable ccx view for master courses if user is not allowed to create ccx.
         elif (
             not ccx and
-            # site configuration PCO_ENABLE_LICENSE_ENFORCEMENT is to control platform default.
-            configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False) and
+            # If Course Licensing is enabled, Disable ccx view for master courses if user is not allowed to create ccx.
+            is_course_licensing_enabled and
             not run_extension_point(
                 'PCO_IS_USER_ALLOWED_TO_CREATE_CCX',
                 user=request.user,
@@ -111,11 +112,15 @@ def coach_dashboard(view):
                 return view(request, course, ccx)
             else:
                 # If user has the staff role at CCX level, then he/she can view ccx coach dashboard for licensed ccxs.
-                if ccx and run_extension_point(
-                    'PCO_IS_USER_ALLOWED_TO_ACCESS_CCX_COACH_TAB',
-                    ccx_id=CCXLocator.from_course_locator(course.id, six.text_type(ccx.id)),
-                    user=request.user,
-                    ):
+                if (
+                    ccx and
+                    is_course_licensing_enabled and
+                    run_extension_point(
+                        'PCO_IS_USER_ALLOWED_TO_ACCESS_CCX_COACH_TAB',
+                        ccx_id=CCXLocator.from_course_locator(course.id, six.text_type(ccx.id)),
+                        user=request.user,
+                    )
+                ):
                     return view(request, course, ccx)
                 # if there is a ccx, we must validate that it is the ccx for this coach
                 role = CourseCcxCoachRole(course_key)
@@ -180,10 +185,11 @@ def dashboard(request, course, ccx=None):
             )
         )
         # if course licensing is enabled, pending enrollments will be in the context.
+        is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
         context['pending_ccx_members'] = run_extension_point(
             'PCO_GET_PENDING_ENROLLMENTS_FOR_CCX',
             ccx_id=ccx_locator,
-        ) if run_extension_point('PCO_ENABLE_COURSE_LICENSING') else []
+        ) if is_course_licensing_enabled else []
         context['gradebook_url'] = reverse(
             'ccx_gradebook', kwargs={'course_id': ccx_locator})
         context['grades_csv_url'] = reverse(
@@ -242,8 +248,10 @@ def create_ccx(request, course, ccx=None):
     # Save display name explicitly
     override_field_for_ccx(ccx, course, 'display_name', name)
 
+    is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
     # if course licensing is enabled, then all units will be shown in schedule.
-    if not run_extension_point('PCO_ENABLE_COURSE_LICENSING'):
+    if not is_course_licensing_enabled:
         # Hide anything that can show up in the schedule
         hidden = 'visible_to_staff_only'
         for chapter in course.get_children():
@@ -273,9 +281,8 @@ def create_ccx(request, course, ccx=None):
     )
 
     assign_staff_role_to_ccx(ccx_id, request.user, course.id)
-    is_course_licensing_enable = configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False)
 
-    if not is_course_licensing_enable:
+    if not is_course_licensing_enabled:
         add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
     # using CCX object as sender here.
@@ -287,7 +294,7 @@ def create_ccx(request, course, ccx=None):
         log.info(u'Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
 
     # Adding an extension point to create the institution_ccx for PearsonVUE.
-    if is_course_licensing_enable:
+    if is_course_licensing_enabled:
         run_extension_point(
             'PCO_CREATE_INSTITUTION_CCX_INSTANCE',
             ccx_id=ccx_id,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -535,11 +535,14 @@ def _section_membership(course, access):
     ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
     enrollment_role_choices = configuration_helpers.get_value('MANUAL_ENROLLMENT_ROLE_CHOICES',
                                                               settings.MANUAL_ENROLLMENT_ROLE_CHOICES)
-    # Hide the membership tab for licensed CCXs from their staff users.
+
+    # if Course Licensing is enabled, hide the membership tab for licensed CCXs from their staff users.
+    is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
     is_licensed_ccx = run_extension_point(
         'PCO_IS_LICENSED_CCX',
         course_id=course.id,
-    )
+    ) if is_course_licensing_enabled else False
 
     section_data = {
         'is_hidden': True if is_licensed_ccx and not access.get('admin', False) else False,
@@ -728,7 +731,10 @@ def _section_data_download(course, access):
         'export_ora2_data_url': reverse('export_ora2_data', kwargs={'course_id': six.text_type(course_key)}),
     }
 
-    if configuration_helpers.get_value('PCO_ENABLE_LICENSE_ENFORCEMENT', False):
+    # If Course Licensing is enabled get_license_usage_url and is_master_course are obtained.
+    is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
+    if is_course_licensing_enabled:
         get_license_usage_url, is_master_course = run_extension_point(
             'PCO_GET_LICENSE_USAGE_URL',
             course_id=course_key,


### PR DESCRIPTION
## TIcket

https://agile-jira.pearson.com/browse/PADV-191

## Description
 
This PR focuses on enabling and disabling the plugin via the `ENABLE_COURSE_LICENSING` site configuration using run_extension_point instead `PCO_ENABLE_LICENSE_ENFORCEMENT`.

## Type of Change

- [x] Remove `PCO_ENABLE_LICENSE_ENFORCEMENT` site configuration validation and use `run_extension_point('PCO_ENABLE_COURSE_LICENSING')`

## PR Related

- https://github.com/Pearson-Advance/course_operations/pull/123

## Testing

- Follow the tests steps in https://github.com/Pearson-Advance/course_operations/pull/123.

## Reviewers

- [x] @Jacatove 
- [x] @alexjmpb  
- [x] @Squirrel18 