### PR TITLE
PADV-483 - Migrate extension points related to course-operations.

### DIFF
--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -5,6 +5,8 @@ Registers the CCX feature for the edX platform.
 
 from django.conf import settings
 from django.utils.translation import gettext_noop
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
+from common.djangoapps.student.auth import is_ccx_course
 
 from common.djangoapps.student.roles import CourseCcxCoachRole
 from xmodule.tabs import CourseTab  # lint-amnesty, pylint: disable=wrong-import-order
@@ -30,6 +32,21 @@ class CcxCourseTab(CourseTab):
         """
         if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
+            return False
+
+        # If Course Licensing is enable, disable CCXCoach tab for master courses if user is not allowed to create ccx.
+        is_course_licensing_enabled = run_extension_point('PCO_ENABLE_COURSE_LICENSING')
+
+        if (
+            not is_ccx_course(course.id) and
+            is_course_licensing_enabled and
+            not run_extension_point(
+                'PCO_IS_USER_ALLOWED_TO_CREATE_CCX',
+                user=user,
+                master_course=course.id,
+            )
+        ):
+            # If course licensing is enable, then regular ccxs are disabled.
             return False
 
         if hasattr(course.id, 'ccx') and bool(user.has_perm(VIEW_CCX_COACH_DASHBOARD, course)):


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-460

## Description

To migrate this plugin correctly, we must follow and apply [the plugin migration guidelines](https://docs.google.com/document/d/1CqF10P-ESG24J80z_OR7AGXgBMN4Bq55GAe7vcSuTI8/edit?usp=sharing) and the documentation created in https://agile-jira.pearson.com/browse/PADV-403.

This ticket add all the features that impact the platform from course_operations.

## Changes Made

- [x] Add run_extenion_points from course operations.
- [x] Add functionallity to create mulplice CCX's. 

## How to test

Follow https://github.com/Pearson-Advance/course_operations/pull/128.

## Reviewers

- [x] @Squirrel18
- [x] @Jacatove