### PR TITLE
PADV-377.1 - Change composite action version in workflows to build and push images

### DIFF
--- a/.github/workflows/build-push-image-main.yml
+++ b/.github/workflows/build-push-image-main.yml
@@ -17,7 +17,7 @@ jobs:
           format: YYYY-MM-DD-HH-mm
 
       - name: Build and push Image
-        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        uses: Pearson-Advance/tutor-build-image-action@v1.0.0
         with:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}

--- a/.github/workflows/build-push-image-stage.yml
+++ b/.github/workflows/build-push-image-stage.yml
@@ -17,7 +17,7 @@ jobs:
           format: YYYY-MM-DD-HH-mm
 
       - name: Build and push Image
-        uses: Pearson-Advance/tutor-build-image-action@0.2.0
+        uses: Pearson-Advance/tutor-build-image-action@v1.0.0
         with:
           python-version: ${{ vars.BUILD_PYTHON_VERSION }}
           tutor-version: ${{ vars.BUILD_TUTOR_VERSION }}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-377

## Description

This PR changes composite action version due to [tutor-build-image-action](https://github.com/Pearson-Advance/tutor-build-image-action) created a new tag (**v1.0.0**).

## Type of Change

- [x] Change composite version in workflow for production.
- [x] Change composite version in workflow for stage.

## How to test

- Create a test PR in the edx-platform repository.
- Merge this PR into the target branch.
- Check that the Github Action is triggered by the PR merge event.
- Check the output of the image build creation for any issues or silent issues.
-  When the process is complete, check the Docker Hub Pearson repository and verify that the image has been built (https://hub.docker.com/repository/docker/paops/edxapp/general).
-  Use the image in a local environment to test it out.

## Reviewers

- [ ] @Squirrel18
- [ ] @alexjmpb 
