### PR TITLE
PADV 511 - Migrate Studio theme

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -30,7 +30,7 @@ from milestones import api as milestones_api
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator
-from organizations.api import add_organization_course, ensure_organization
+from organizations.api import add_organization_course, ensure_organization, get_organizations
 from organizations.exceptions import InvalidOrganizationException
 from rest_framework.exceptions import ValidationError
 
@@ -537,7 +537,13 @@ def course_listing(request):
 
     optimization_enabled = GlobalStaff().has_user(request.user) and ENABLE_GLOBAL_STAFF_OPTIMIZATION.is_enabled()
 
-    org = request.GET.get('org', '') if optimization_enabled else None
+    org = None
+    org_names_list = []
+
+    if optimization_enabled:
+        org = request.GET.get('org') if request.GET.get('org') else None
+        org_names_list = [(org['short_name']) for org in get_organizations() if 'short_name' in org]
+
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)
     user = request.user
     libraries = []
@@ -586,7 +592,8 @@ def course_listing(request):
         'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
         'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
         'optimization_enabled': optimization_enabled,
-        'active_tab': 'courses'
+        'active_tab': 'courses',
+        'org_names_list': org_names_list,
     })
 
 


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-511

## Description

This PR aims to migrate the pearson-studio-theme to Olive. This adds the necessary context to the index.html template so the organization dropdown can get the organization list and apply the filter. This PR is related to this other in openedx-themes https://github.com/Pearson-Advance/openedx-themes/pull/241

## Changes Made

- [x] Add organizations list context

## How to test

- Change to the branch vue/PADV-511 in your edx-platform
- Activate the studio_home.enable_global_staff_optimization waffle switch in the studio admin page
- Enable the ORGANIZATION_APP feature in Studio
- You should be able to access the org_names_list variable inside the index.html and should contain a list with the organizations
- To test you can enable the pearson-studio-theme and verify that the dropdown contains the sites created

# Screenshots

![Screenshot from 2023-05-23 07-57-47](https://github.com/Pearson-Advance/edx-platform/assets/62396424/e71839b3-1691-41c0-95ad-3a7d43b1ea15)

![Screenshot from 2023-05-23 07-57-53](https://github.com/Pearson-Advance/edx-platform/assets/62396424/7ee80c05-13fc-488e-bec8-b35540415785)

## Reviewers

- [ ] @anfbermudezme 
- [ ] @kuipumu 
- [x] @sergivalero20 