### PR TITLE
PADV 513 - Migrate SAML features

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -890,17 +890,25 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
                 setattr(model, field, provider_value)
 
         # Generate fullname only for IES IDP.
+        # We deliberately left these values hard-coded instead of using Django settings because
+        # it would force us to add custom settings to the edx platform code,
+        # which we try to avoid as we might lose track of that kind of setting.
         ies_entity_ids = [
             'https://iam-stage.pearson.com:443/auth/saml-idp-uid',
             'https://iam.pearson.com:443/auth/saml-idp-uid',
         ]
+        first_name = details.get('first_name')
+        last_name = details.get('last_name')
 
-        if (details.get('first_name') and details.get('last_name') and
-            current_provider.entity_id in ies_entity_ids):
-            fullname_value = '{} {}'.format(details.get('first_name'), details.get('last_name'))
+        if (
+            first_name and
+            last_name and
+            current_provider.entity_id in ies_entity_ids
+        ):
+            fullname_value = f'{first_name} {last_name}'
             changed['fullname'] = fullname_value
 
-            setattr(user.profile, 'name', fullname_value)
+            setattr(user.profile, 'name', fullname_value)  # pylint: disable=literal-used-as-attribute
 
         if changed:
             logger.info(

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -889,6 +889,19 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
                 changed[provider_field] = current_value
                 setattr(model, field, provider_value)
 
+        # Generate fullname only for IES IDP.
+        ies_entity_ids = [
+            'https://iam-stage.pearson.com:443/auth/saml-idp-uid',
+            'https://iam.pearson.com:443/auth/saml-idp-uid',
+        ]
+
+        if (details.get('first_name') and details.get('last_name') and
+            current_provider.entity_id in ies_entity_ids):
+            fullname_value = '{} {}'.format(details.get('first_name'), details.get('last_name'))
+            changed['fullname'] = fullname_value
+
+            setattr(user.profile, 'name', fullname_value)
+
         if changed:
             logger.info(
                 '[THIRD_PARTY_AUTH] User performed SSO and data was synchronized. '

--- a/docs/custom_features_documentation.md
+++ b/docs/custom_features_documentation.md
@@ -1,0 +1,51 @@
+# Custom Features Migration
+
+## SSO Logout Feature
+
+### Overview
+The SSO Logout feature adds an extension point to integrate the Pearson Core Single Sign-On (SSO) logout functionality into the system.
+
+### Test Cases
+
+To test the SSO Logout feature, follow these steps:
+
+1. Configure the site configurations:
+   - Set the value of `IES_SESSION_COOKIE_NAME` to the appropriate session cookie name.
+   - Set the value of `IES_LOGOUT_ENDPOINT_URL` to the URL of the logout endpoint.
+
+2. Perform a logout from the LMS:
+   - Ensure that the `ies_sso_logout` function from Pearson Core is being called during the logout process.
+
+3. Verify the expected behavior:
+   - Confirm that the Pearson Core SSO logout feature is triggered.
+
+## Full Name Construction
+
+The Full Name Construction feature enhances the user_details_force_sync pipeline to construct the full name attribute from the first name and last name attributes, compensating for the lack of a full name attribute sent by IES.
+
+### Test Cases
+
+Follow these steps to configure and test the Full Name Construction feature:
+
+1. Configure a SAML IdP and SP in the edx-platform:
+   - Refer to the [EDX documentation](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_SAML_IdP.html) for instructions on configuring a SAML IdP and SP.
+
+2. Configure the SAML IdP in the Django admin page:
+   - Leave the "Full Name Attribute" field blank.
+   - Set an arbitrary value for the "Full Name Default Value" attribute.
+   - Enable the Sync learner profile data field.
+
+3. Ensure the SAML IdP passes the first name and last name attributes:
+   - During the account creation process with SAML, make sure that the SAML IdP passes both the first name and last name attributes.
+
+4. Add the SAML IdP entity ID to the list in the code:
+   - Update the code to include the entity ID of your SAML IdP in the entity_id list.
+
+5. Create an account with SAML:
+   - When creating an account using SAML authentication, ensure that the first name and last name attributes are passed correctly.
+
+6. Verify the Full Name attribute:
+   - After the account is created, navigate to your profile page.
+   - Confirm that the Full Name attribute is constructed by combining the first name and last name values.
+
+If the first and last name attributes are not passed, the full name should contain the default value

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -12,6 +12,7 @@ from django.utils.http import urlencode
 from django.views.generic import TemplateView
 from oauth2_provider.models import Application
 
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as_expected
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
@@ -81,6 +82,14 @@ class LogoutView(TemplateView):
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
+
+        # This module makes a POST request to the IES logout endpoint
+        # to allow us to log out the user by clicking
+        # the "Sign Out" button on the platform.
+        run_extension_point(
+            'PEARSON_CORE_SSO_LOGOUT_MODULE',
+            request=request,
+        )
 
         mark_user_change_as_expected(None)
         return response


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-513

## Description

This PR aims to migrate the SAML custom features developed in the edx-platform. It includes the full name construction from first name and last name feature and the extension point to remove the session from IES. The TPA features was not included since we decided to move it to another ticket.

## Changes Made

- [x] Cherry pick logout extension point from #50 
- [x] Cherry pick full name construction pipeline step from #47 

## How to test

For the full name construction
- Configure a SAML idp and a sp in the edx-platform (https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_SAML_IdP.html)
- in the idp config leave the field full name attribute blank and set an arbitrary value to the attribute full name default value.
- When creating the account with SAML, be sure that the idp passes the first name and last name attributes
- Add the SAML idp entity id to the list in the code
- When the account is created, go to your profile and you must see that the full name value is the first name and the last name combined

For the logout feature
- Configure the site configurations IES_SESSION_COOKIE_NAME, IES_LOGOUT_ENDPOINT_URL
- Be sure that the ies_sso_logout function from pearson core is being called when you log out from the lms

## Reviewers

- [ ] @anfbermudezme 
- [ ] @kuipumu 
- [ ] @Squirrel18  