### PR TITLE
PADV 554 - MFE URLs site aware.

### DIFF
--- a/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
+++ b/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py
@@ -52,8 +52,10 @@ def send_ace_message(goal):
 
     course_home_url = get_learning_mfe_home_url(course_key=goal.course_key, url_fragment='home')
 
-    goals_unsubscribe_url = f'{settings.LEARNING_MICROFRONTEND_URL}/goal-unsubscribe/{goal.unsubscribe_token}'
-
+    goals_unsubscribe_url = (
+        f'{configuration_helpers.get_value("LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL)}'
+        f'/goal-unsubscribe/{goal.unsubscribe_token}'
+    )
     language = get_user_preference(user, LANGUAGE_KEY)
 
     # Code to allow displaying different banner images for different languages

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -66,6 +66,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
 )
 from openedx.core.djangoapps.django_comment_common.utils import ThreadContext
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
 
 User = get_user_model()
@@ -272,7 +273,10 @@ def redirect_forum_url_to_new_mfe(request, course_id):
 
     redirect_url = None
     if discussions_mfe_enabled:
-        mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+        mfe_base_url = configuration_helpers.get_value(
+            'DISCUSSIONS_MICROFRONTEND_URL',
+            settings.DISCUSSIONS_MICROFRONTEND_URL,
+        )
         redirect_url = f"{mfe_base_url}/{str(course_key)}"
     return redirect_url
 
@@ -332,7 +336,10 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
     if discussions_mfe_enabled:
-        mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+        mfe_base_url = configuration_helpers.get_value(
+            'DISCUSSIONS_MICROFRONTEND_URL',
+            settings.DISCUSSIONS_MICROFRONTEND_URL,
+        )
         if thread_id:
             redirect_url = f"{mfe_base_url}/{str(course_key)}/posts/{thread_id}"
     return redirect_url
@@ -652,7 +659,10 @@ def user_profile(request, course_key, user_id):
         else:
             discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
             if discussions_mfe_enabled:
-                mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+                mfe_base_url = configuration_helpers.get_value(
+                    'DISCUSSIONS_MICROFRONTEND_URL',
+                    settings.DISCUSSIONS_MICROFRONTEND_URL,
+                )
                 return redirect(f"{mfe_base_url}/{str(course_key)}/learners")
 
             tab_view = CourseTabView()

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -583,8 +583,13 @@ def _section_student_admin(course, access):
         ),
         'spoc_gradebook_url': reverse('spoc_gradebook', kwargs={'course_id': str(course_key)}),
     }
-    if is_writable_gradebook_enabled(course_key) and settings.WRITABLE_GRADEBOOK_URL:
-        section_data['writable_gradebook_url'] = f'{settings.WRITABLE_GRADEBOOK_URL}/{str(course_key)}'
+    writable_gradebook_url = configuration_helpers.get_value(
+        'WRITABLE_GRADEBOOK_URL',
+        settings.WRITABLE_GRADEBOOK_URL,
+    )
+
+    if is_writable_gradebook_enabled(course_key) and writable_gradebook_url:
+        section_data['writable_gradebook_url'] = f'{writable_gradebook_url}/{str(course_key)}'
     return section_data
 
 

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -21,6 +21,7 @@ from common.djangoapps.util.query import use_read_replica_if_available
 from lms.djangoapps.verify_student.message_types import VerificationExpiry
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.lib.celery.task_utils import emulate_http_request
@@ -191,7 +192,10 @@ class Command(BaseCommand):
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification',
+            'lms_verification_link': (
+                f'{configuration_helpers.get_value("ACCOUNT_MICROFRONTEND_URL", settings.ACCOUNT_MICROFRONTEND_URL)}'
+                f'/id-verification'
+            ),
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -232,7 +232,10 @@ class IDVerificationService:
         Returns a string:
             Returns URL for IDV on Account Microfrontend
         """
-        location = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        location = (
+            f'{configuration_helpers.get_value("ACCOUNT_MICROFRONTEND_URL", settings.ACCOUNT_MICROFRONTEND_URL)}'
+            f'/id-verification'
+        )
         if course_id:
             location += f'?course_id={quote(str(course_id))}'
         return location

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1122,7 +1122,10 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
     elif result == "FAIL":
         log.debug("Denying verification for %s", receipt_id)
         attempt.deny(json.dumps(reason), error_code=error_code)
-        reverify_url = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        reverify_url = (
+            f'{configuration_helpers.get_value("ACCOUNT_MICROFRONTEND_URL", settings.ACCOUNT_MICROFRONTEND_URL)}'
+            f'/id-verification'
+        )
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url
         verification_status_email_vars['faq_url'] = settings.ID_VERIFICATION_SUPPORT_LINK

--- a/openedx/core/djangoapps/discussions/url_helpers.py
+++ b/openedx/core/djangoapps/discussions/url_helpers.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 def _get_url_with_view_query_params(path: str, view: Optional[str] = None) -> str:
@@ -20,9 +21,13 @@ def _get_url_with_view_query_params(path: str, view: Optional[str] = None) -> st
         (str) URL link for MFE
 
     """
-    if settings.DISCUSSIONS_MICROFRONTEND_URL is None:
+    discussion_microfontend_url = configuration_helpers.get_value(
+        'DISCUSSIONS_MICROFRONTEND_URL',
+        settings.DISCUSSIONS_MICROFRONTEND_URL,
+    )
+    if not discussion_microfontend_url:
         return ''
-    url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{path}"
+    url = f"{discussion_microfontend_url}/{path}"
 
     query_params = {}
     if view == "in_context":

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -58,7 +58,10 @@ def account_settings(request):
 
     """
     if should_redirect_to_account_microfrontend():
-        url = settings.ACCOUNT_MICROFRONTEND_URL
+        url = configuration_helpers.get_value(
+            'ACCOUNT_MICROFRONTEND_URL',
+            settings.ACCOUNT_MICROFRONTEND_URL,
+        )
 
         duplicate_provider = pipeline.get_duplicate_provider(messages.get_messages(request))
         if duplicate_provider:

--- a/openedx/features/course_experience/url_helpers.py
+++ b/openedx/features/course_experience/url_helpers.py
@@ -15,6 +15,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves.urllib.parse import urlencode, urlparse
 
 from lms.djangoapps.courseware.toggles import courseware_mfe_is_active
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.search import navigation_index, path_to_location  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -158,7 +159,10 @@ def make_learning_mfe_courseware_url(
     strings. They're only ever used to concatenate a URL string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
-    mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
+    mfe_link = (
+        f'{configuration_helpers.get_value("LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL)}'
+        f'/course/{course_key}'
+    )
 
     if sequence_key:
         mfe_link += f'/{sequence_key}'
@@ -188,7 +192,10 @@ def get_learning_mfe_home_url(
     `url_fragment` is an optional string.
     `params` is an optional QueryDict object (e.g. request.GET)
     """
-    mfe_link = f'{settings.LEARNING_MICROFRONTEND_URL}/course/{course_key}'
+    mfe_link = (
+        f'{configuration_helpers.get_value("LEARNING_MICROFRONTEND_URL", settings.LEARNING_MICROFRONTEND_URL)}'
+        f'/course/{course_key}'
+    )
 
     if url_fragment:
         mfe_link += f'/{url_fragment}'
@@ -206,6 +213,9 @@ def is_request_from_learning_mfe(request: HttpRequest):
     if not settings.LEARNING_MICROFRONTEND_URL:
         return False
 
-    url = urlparse(settings.LEARNING_MICROFRONTEND_URL)
+    url = urlparse(configuration_helpers.get_value(
+        "LEARNING_MICROFRONTEND_URL",
+        settings.LEARNING_MICROFRONTEND_URL,
+    ))
     mfe_url_base = f'{url.scheme}://{url.netloc}'
     return request.META.get('HTTP_REFERER', '').startswith(mfe_url_base)

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -44,7 +44,10 @@ def learner_profile(request, username):
         GET /account/profile
     """
     if should_redirect_to_profile_microfrontend():
-        profile_microfrontend_url = f"{settings.PROFILE_MICROFRONTEND_URL}{username}"
+        profile_microfrontend_url = (
+            f"{configuration_helpers.get_value('PROFILE_MICROFRONTEND_URL', settings.PROFILE_MICROFRONTEND_URL)}"
+            f"{username}"
+        )
         if request.GET:
             profile_microfrontend_url += f'?{request.GET.urlencode()}'
         return redirect(profile_microfrontend_url)


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-554

## Description

This PR aims to make all the URLs that are related to all the currently active MFEs (learning, discussions, gradebook, profile and account) site aware. It adds a configuration_helpers.get_value to every MFE URL so it can get the value from site configuration.

## Type of Change

- [x] Change occurrences of LEARNING_MICROFRONTEND_URL so it gets the value from site configuration
- [x] Change occurrences of DISCUSSIONS_MICROFRONTEND_URL so it gets the value from site configuration
- [x] Change occurrences of WRITABLE_GRADEBOOK_URL so it gets the value from site configuration
- [x] Change occurrences of PROFILE_MICROFRONTEND_URL so it gets the value from site configuration
- [x] Change occurrences of ACCOUNT_MICROFRONTEND_URL so it gets the value from site configuration

## How to test

- Checkout edx-platform to this branch
- Create a site and a site configuration containing the name of the setting as a key and the url as the value. Like this:
```    "LEARNING_MICROFRONTEND_URL": "http://site1.learningtest.test",
    "WRITABLE_GRADEBOOK_URL": "http://site1.gradebooktest.test",
    "PROFILE_MICROFRONTEND_URL": "http://site1.profiletest.test",
    "ACCOUNT_MICROFRONTEND_URL": "http://site1.accounttest.test",
    "DISCUSSIONS_MICROFRONTEND_URL": "http://site1.discussiontest.test"
```
- In the site, test that whenever you click on a link that should redirect to one of the MFEs, it redirects to the configured URL.

If you want to test each feature in detail, you can search in the edx-platform for the setting name, see where is being used and test that specific feature.

## Reviewers

- [ ] @Squirrel18   
- [ ] @anfbermudezme 
- [ ] @sergivalero20  