### PR TITLE
PADV-549 - Disable data sharing consent.

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -108,6 +108,11 @@ class ConsentApiClient:
         conceptual scope of the consent involved in the request.
         """
 
+        # If enterprise-catalog is not enabled it is necessary disable data sharing consent
+        # for enterprise customers.
+        if configuration_helpers.get_value('DISABLE_DATA_SHARING_CONSENT', False):
+            return False
+
         # Call the endpoint with the given kwargs, and check the value that it provides.
         response = self.client.get(self.consent_endpoint, params=kwargs)
         response.raise_for_status()


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-549

## Description

After the enterprise migration https://agile-jira.pearson.com/browse/PADV-489, it was found that when an enterprise customer has data sharing consent enabled and enterprise-catalog is not enabled, the URL where a new enterprise enrollment is directed leads nowhere. Therefore, in this PR the option to redirect to the enterprise-catalog is disabled and it must be redirected to the expected URL, behavior that we currently have in Juniper, through a site configuration called `DISABLE_DATA_SHARING_CONSENT`.

This PR is created to completely disable data sharing consent from enterprise. Following this PR https://github.com/Pearson-Advance/edx-enterprise/pull/8 and https://github.com/Pearson-Advance/edx-enterprise/pull/9, we relized that it's necessary disable this feature also in edx-platform.

## Changes Made

- [x] Add feature flag to disable data sharing consent in olive.