### PR TITLE
PADV-806: feat: add course created event signals

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -21,11 +21,14 @@ from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from django.utils.timezone import timezone
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 from six import StringIO
 
+from openedx_events.content_authoring.data import CourseData
+from openedx_events.content_authoring.signals import COURSE_CREATED
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseCcxCoachRole
@@ -300,6 +303,14 @@ def create_ccx(request, course, ccx=None):
             custom_course=ccx,
             user=request.user,
         )
+
+    # .. event_implemented_name: COURSE_CREATED
+    COURSE_CREATED.send_event(
+        time=datetime.datetime.now(tz=timezone.utc),
+        course=CourseData(
+            course_key=ccx_id,
+        )
+    )
 
     return redirect(url)
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -100,4 +100,4 @@ pytz==2022.2.1
 
 # openedx-events>0.13.0 causes test failures due to breaking changes
 # These broken tests will be fixed in a separate PR
-openedx-events==0.13.0
+openedx-events==8.3.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -759,7 +759,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-django-pyfs==3.2.1
     # via xblock
-openedx-events==0.13.0
+openedx-events==8.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -991,7 +991,7 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   xblock
-openedx-events==0.13.0
+openedx-events==8.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -942,7 +942,7 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/edx/base.txt
     #   xblock
-openedx-events==0.13.0
+openedx-events==8.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt

--- a/xmodule/modulestore/mixed.py
+++ b/xmodule/modulestore/mixed.py
@@ -13,6 +13,10 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 
+from openedx_events.content_authoring.data import CourseData
+from openedx_events.content_authoring.signals import COURSE_CREATED
+
+from django.utils.timezone import datetime, timezone
 from xmodule.assetstore import AssetMetadata
 
 from . import XMODULE_FIELDS_WITH_USAGE_KEYS, ModuleStoreWriteBase
@@ -666,6 +670,14 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         # add new course to the mapping
         self.mappings[course_key] = store
+
+        # .. event_implemented_name: COURSE_CREATED
+        COURSE_CREATED.send_event(
+            time=datetime.now(timezone.utc),
+            course=CourseData(
+                course_key=course_key,
+            )
+        )
 
         return course
 


### PR DESCRIPTION
## Description

This PR adds the ``COURSE_CREATED`` signal in olive version.

## Testing instruction

1. Use this branch ``vue/PADV-806-course-created`` to use the necessary changes
2. Setup frontend-app-library-authoring if not done before:

```bash
    from .devstack import FEATURES
    FEATURES['ENABLE_LIBRARY_AUTHORING_MICROFRONTEND'] = True
    BLOCKSTORE_API_AUTH_TOKEN = 'edxapp-insecure-devstack-key'
```
3. Set up the blockstore to run in devstack ([ref](https://github.com/openedx/blockstore)) by running the following from the studio shell (make studio-shell):
```bash
# Configure blockstore to run inside LMS/Studio (instead of as an external service)
./manage.py cms waffle_switch --create blockstore.use_blockstore_app_api on

./manage.py cms shell  # enter python code below

# Create a "Collection" that new content libraries / xblocks can be created within:
from blockstore.apps.bundles.models import Collection
coll, _ = Collection.objects.get_or_create(title='Devstack Content Collection', uuid='11111111-2111-4111-8111-111111111111')

# Create an "Organization":
from organizations.models import Organization
Organization.objects.get_or_create(short_name='DeveloperInc', defaults={'name': 'DeveloperInc', 'active': True})
```
4. Add below snippet somewhere, for example in cms/djangoapps/contentstore/signals/handlers.py:

```bash
from openedx_events.content_authoring.signals import COURSE_CREATED
COURSE_CREATED.connect(lambda **x: print("test_event: ", x))
```

5. Open studio in http://localhost:18010/
6. Open studio logs monitoring:
```bash
make studio-logs | grep test_event:
```
7. Create a course
Check the log for ``COURSE_CREATED``

8. Should see something like:

```bash
make studio-logs | grep test_event:
edx.devstack-olive.master.studio   | test_event:  {'signal': <OpenEdxPublicSignal: org.openedx.content_authoring.xblock.updated.v1>, 'sender': None, 'xblock_info': XBlockData(usage_key=BlockUsageLocator(CourseLocator('demo', 'demo1', '2020', None, None), 'course', 'course'), block_type='course', version=BlockUsageLocator(CourseLocator('demo', 'demo1', '2020', 'draft-branch', ObjectId('655df4e81593fe8f4610c9a8')), 'course', 'course')), 'metadata': EventsMetadata(event_type='org.openedx.content_authoring.xblock.updated.v1', id=UUID('39d5e9d2-8933-11ee-8a88-0242ac130010'), minorversion=0, source='openedx/cms/web', sourcehost='studio.devstack.edx', time=datetime.datetime(2023, 11, 22, 12, 32, 40, 172109, tzinfo=datetime.timezone.utc), sourcelib=(8, 3, 0))}
edx.devstack-olive.master.studio   | test_event:  {'signal': <OpenEdxPublicSignal: org.openedx.content_authoring.xblock.created.v1>, 'sender': None, 'xblock_info': XBlockData(usage_key=BlockUsageLocator(CourseLocator('demo', 'demo2', '2020', None, None), 'course_info', 'updates'), block_type='course_info', version=BlockUsageLocator(CourseLocator('demo', 'demo2', '2020', 'draft-branch', ObjectId('655e011b89ca06c615ebfe56')), 'course_info', 'updates')), 'metadata': EventsMetadata(event_type='org.openedx.content_authoring.xblock.created.v1', id=UUID('7fb4138c-893a-11ee-a5a4-0242ac130010'), minorversion=0, source='openedx/cms/web', sourcehost='studio.devstack.edx', time=datetime.datetime(2023, 11, 22, 13, 24, 43, 867932, tzinfo=datetime.timezone.utc), sourcelib=(8, 3, 0))}
```

9. Now create a CCX, the signal should be like a course created

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-806

## Other information

Reference PR edx-platform: https://github.com/openedx/edx-platform/pull/32599
Reference PR openedx/events: https://github.com/openedx/openedx-events/pull/244
