### PR TITLE
PADV-815 use the ccx data complete for course created openedx event

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -308,7 +308,7 @@ def create_ccx(request, course, ccx=None):
     COURSE_CREATED.send_event(
         time=datetime.datetime.now(tz=timezone.utc),
         course=CourseData(
-            course_key=ccx_id,
+            course_key=ccx,
         )
     )
 


### PR DESCRIPTION
## Description

This PR is just to use the ``CCX`` model to use data that is necessary in Skillable Plugin implementation ``GetOrCreateClass``
https://github.com/Pearson-Advance/skillable-plugin/pull/3

Issue: [PADV-815](https://agile-jira.pearson.com/browse/PADV-815)