### PR TITLE
PADV 1018 - Changes to primary course not being reflected in the CCXs

### DIFF
--- a/lms/djangoapps/ccx/apps.py
+++ b/lms/djangoapps/ccx/apps.py
@@ -1,0 +1,18 @@
+"""
+LMS CCX application configuration
+Signal handlers are connected here.
+"""
+from django.apps import AppConfig
+
+
+class CCXConfig(AppConfig):
+    """
+    Application Configuration for CCX.
+    """
+    name = 'lms.djangoapps.ccx'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import tasks # pylint: disable=unused-import


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1018

## Description

As 1018 describes, right now none of the CCXs are updating their outline when the outline on their corresponding master course is changed. The way it should work is, whenever the outline of a course is updated in studio, it emits the signal "course_published" and this signal should be captured by the CCX app and should update all children CCX for that course, however because the CCX app is not installed in Studio, this causes the course_published signal to not be aware of the receivers in the CCX app. Also the CCX app does not have an apps.py and thus cannot "export" the signal. This PR aims to add an apps.py to the CCX app.

## Changes

- Add apps.py to lms.djangoapps.ccx and import the signals.

## How to test?

- Setup devstack.
- Create a course with CCX enabled.
- Create a CCX
- Any changes in the outline that you make in the master course should not be reflected on the CCX.
- Checkout to this branch.
- Inside cms.envs.devstack_docker, add the following settings: 
```
INSTALLED_APPS += ['lms.djangoapps.ccx', 'lms.djangoapps.program_enrollments']
BULK_EMAIL_DEFAULT_RETRY_DELAY = 30
BULK_EMAIL_MAX_RETRIES = 5
```
- Now any change in the outline you make to the master course should be also in the CCX.