### PR TITLE
feat: regex pattern set for Score (for override only) field

### DIFF
--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -9,6 +9,10 @@ var StaffDebug = (function() {
         return string.replace(/[.*+?^:${}()|[\]\\]/g, '\\$&');
     };
 
+    var sanitizeScore = function(string){
+        return string.replace(/[^0-9.]/g, '');
+    };
+
     var getUser = function(locationName) {
         var sanitizedLocationName = sanitizeString(locationName);
         var uname = $('#sd_fu_' + sanitizedLocationName).val();
@@ -24,6 +28,7 @@ var StaffDebug = (function() {
         if (score === '') {
             score = $('#sd_fs_' + sanitizedLocationName).attr('placeholder');
         }
+        score = sanitizeScore(score)
         return score;
     };
 

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -72,7 +72,7 @@ ${block_content | n, decode.utf8}
       % if can_override_problem_score:
       <div>
         <label for="sd_fs_${location.block_id}">${_('Score (for override only)')}:</label>
-        <input type="text" tabindex="0" id="sd_fs_${location.block_id}" placeholder="0"/>
+        <input type="number" tabindex="0" id="sd_fs_${location.block_id}" placeholder="0"/>
         <label for="sd_fs_${location.block_id}"> / ${max_problem_score}</label>
       </div>
       % endif


### PR DESCRIPTION
# Description
This PR includes a fix to prevent Reflected Cross-Site Scripting on Score (for override only) field. This attack is visible in the following image: 
![image](https://github.com/Pearson-Advance/edx-platform/assets/111355257/cdbd377c-2c75-465d-a6cd-ebcb6df7d6fe)

# Changes
- Changes input type to number to filter only numbers.
- Adds a sanitize function to remove extra characters on the score variable.

# How to test:
In devstack:
- Get the devstack up and running from this branch
- On a Blank Common Problem and with a staff user, click on `STAFF DEBUG INFO`

![image](https://github.com/Pearson-Advance/edx-platform/assets/111355257/c244e84f-2325-4dde-9feb-f9bf828165bb)

- In Score (for override only) field, paste this code: `<script>alert('yes')</script>`, click on `Override Score` button and no alert should be displayed.
![image](https://github.com/Pearson-Advance/edx-platform/assets/111355257/16e46601-89f8-4e62-96f6-4f75cfdb3e6c)
