### PR TITLE
PADV-1019 - Delete run_extension_point in course_operations

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -301,15 +301,6 @@ def create_ccx(request, course, ccx=None):
     for rec, response in responses:
         log.info('Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
 
-    # Adding an extension point to create the institution_ccx for PearsonVUE.
-    if is_course_licensing_enabled:
-        run_extension_point(
-            'PCO_CREATE_INSTITUTION_CCX_INSTANCE',
-            ccx_id=ccx_id,
-            custom_course=ccx,
-            user=request.user,
-        )
-
     # .. event_implemented_name: COURSE_CREATED
     COURSE_CREATED.send_event(
         time=datetime.datetime.now(tz=timezone.utc),


### PR DESCRIPTION
# Description
We need to migrate our implementation of course_operations features to openedx supported technologies such as events and filters. For that, we delete the run_extension_point related to the creation of a course.

# Changes
- [x] Delete run_extension_point

# How to test:
- Create a course in course_operations
