### PR TITLE
PADV 1134 - Global staff and superusers should have access to the CCX gradebook.

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -230,6 +230,7 @@ def course_author_access_required(view):
             user_has_gradebook_access = any([
                 CourseStaffRole(course_key).has_user(request.user),
                 CourseInstructorRole(course_key).has_user(request.user),
+                request.user.is_staff,
             ])
             if is_ccx_course(course_key) and user_has_gradebook_access:
                 return view(self, request, course_key, *args, **kwargs)


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1134

## Description

Right now, only course staff and course instructors are able to access the gradebook of a CCX, there is a requirement of allowing global staffs to access the gradebook too, since per business logic, every permission a course staff has, global staffs should also have those permissions. This PR aims to add the capacity to global staffs to access to the gradebook of a ccx.

## How to test?

- Setup devstack
- Checkout to this branch
- Create a CCX (licensed or not)
- Verify the access to the gradebook with a global staff (turn on the is_staff attribute of the user)