### PR TITLE
feat: Installing new openedx-events version and fixing requirements

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -100,4 +100,4 @@ pytz==2022.2.1
 
 # openedx-events>0.13.0 causes test failures due to breaking changes
 # These broken tests will be fixed in a separate PR
-openedx-events==8.3.0
+openedx-events==9.10.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -759,7 +759,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-django-pyfs==3.2.1
     # via xblock
-openedx-events==8.3.0
+openedx-events==9.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -991,7 +991,7 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   xblock
-openedx-events==8.3.0
+openedx-events==9.10.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1270

## Description

This PR aims to update the openedx-events version from 8.3.0 to 9.10.0. The change was made manually since compiling it causes an error and fixing it requires a bigger effort. A new PR will be opened to solve the issue.

![image](https://github.com/Pearson-Advance/edx-platform/assets/62396424/0895707f-c74d-495e-94d2-51460567cc0d)


## How to test?

- Setup devstack
- Checkout to this branch
- Run `make requirements` inside of a lms shell
- Run `pip list`, openedx-events should be in the version 9.10.0.