### PR TITLE
PADV 1276 - Move edx-platform changes to our repository

### DIFF
--- a/lms/djangoapps/grades/event_utils.py
+++ b/lms/djangoapps/grades/event_utils.py
@@ -1,0 +1,49 @@
+from openedx_events.learning.data import (
+    CcxCourseData,
+    CcxCoursePassingStatusData,
+    CourseData,
+    CoursePassingStatusData,
+    UserData,
+    UserPersonalData
+)
+from openedx_events.learning.signals import CCX_COURSE_PASSING_STATUS_UPDATED, COURSE_PASSING_STATUS_UPDATED
+
+
+def emit_course_passing_status_update(user, course_id, is_passing):
+    if hasattr(course_id, 'ccx'):
+        CCX_COURSE_PASSING_STATUS_UPDATED.send_event(
+            course_passing_status=CcxCoursePassingStatusData(
+                is_passing=is_passing,
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=user.username,
+                        email=user.email,
+                        name=user.get_full_name(),
+                    ),
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+                course=CcxCourseData(
+                    ccx_course_key=course_id,
+                    master_course_key=course_id.to_course_locator(),
+                ),
+            )
+        )
+    else:
+        COURSE_PASSING_STATUS_UPDATED.send_event(
+            course_passing_status=CoursePassingStatusData(
+                is_passing=is_passing,
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=user.username,
+                        email=user.email,
+                        name=user.get_full_name(),
+                    ),
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+                course=CourseData(
+                    course_key=course_id,
+                ),
+            )
+        )

--- a/lms/djangoapps/grades/events.py
+++ b/lms/djangoapps/grades/events.py
@@ -16,6 +16,7 @@ from common.djangoapps.track.event_transaction_utils import (
     get_event_transaction_type,
     set_event_transaction_type
 )
+from lms.djangoapps.grades.event_utils import emit_course_passing_status_update
 from lms.djangoapps.grades.signals.signals import SCHEDULE_FOLLOW_UP_SEGMENT_EVENT_FOR_COURSE_PASSED_FIRST_TIME
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.enterprise_support.context import get_enterprise_event_context
@@ -190,6 +191,8 @@ def course_grade_now_passed(user, course_id):
             }
         )
 
+    emit_course_passing_status_update(user, course_id, is_passing=True)
+
 
 def course_grade_now_failed(user, course_id):
     """
@@ -208,6 +211,8 @@ def course_grade_now_failed(user, course_id):
                 'event_transaction_type': str(get_event_transaction_type())
             }
         )
+
+    emit_course_passing_status_update(user, course_id, is_passing=False)
 
 
 def fire_segment_event_on_course_grade_passed_first_time(user_id, course_locator):


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1276

## Description

This PR aims to add the changes made by Racoongang to our edx-platform repository. These changes include adding the following openedx-events triggers:

- `COURSE_PASSING_STATUS_UPDATED`
- `CCX_COURSE_PASSING_STATUS_UPDATED`

## Changes made

Cherrypick the follwing commits from the branch aci.main on https://github.com/raccoongang/edx-platform.

- https://github.com/raccoongang/edx-platform/pull/2552
- https://github.com/raccoongang/edx-platform/pull/2535
- https://github.com/raccoongang/edx-platform/pull/2533
- https://github.com/raccoongang/edx-platform/pull/2531
- https://github.com/raccoongang/edx-platform/pull/2529
- https://github.com/raccoongang/edx-platform/pull/2527
- https://github.com/raccoongang/edx-platform/pull/2526
- https://github.com/raccoongang/edx-platform/pull/2520

Note that the changes related to configuring the event bus are out of the scope of this PR, these changes will be implemented later based on the results of PADV-1228.

## How to test?

- Setup devstack
- Checkout to this branch
- Run `make requirements` inside of a lms shell
- In a plugin like pearson-core, add a openedx-events receiver for the signal `openedx_events.learning.signals.COURSE_PASSING_STATUS_UPDATED`.
- Configure grading for a course.
- Verify that when the score of a learner is updated the signal receiver is triggered.
- Repeat but now with `openedx_events.learning.signals.CCX_COURSE_PASSING_STATUS_UPDATED`.