### PR TITLE
PADV-1346: Backport edx-platform changes needed for Event Bus to work on our olive instance.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -19,7 +19,6 @@ from django.urls import reverse_lazy
 from edx_django_utils.plugins import add_plugins
 from path import Path as path
 
-
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
 from .common import *
@@ -84,6 +83,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
         'MKTG_URL_LINK_MAP',
         'MKTG_URL_OVERRIDES',
         'REST_FRAMEWORK',
+        'EVENT_BUS_PRODUCER_CONFIG',
     ]
     for key in KEYS_WITH_MERGED_VALUES:
         if key in __config_copy__:

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -25,6 +25,7 @@ import yaml
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from django.core.exceptions import ImproperlyConfigured
 from edx_django_utils.plugins import add_plugins
+from openedx_events.event_bus import merge_producer_configs
 from path import Path as path
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
@@ -83,6 +84,7 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
         'MKTG_URL_LINK_MAP',
         'MKTG_URL_OVERRIDES',
         'REST_FRAMEWORK',
+        'EVENT_BUS_PRODUCER_CONFIG',
     ]
     for key in KEYS_WITH_MERGED_VALUES:
         if key in __config_copy__:
@@ -1080,3 +1082,7 @@ COURSE_LIVE_GLOBAL_CREDENTIALS["BIG_BLUE_BUTTON"] = {
     "SECRET": ENV_TOKENS.get('BIG_BLUE_BUTTON_GLOBAL_SECRET', None),
     "URL": ENV_TOKENS.get('BIG_BLUE_BUTTON_GLOBAL_URL', None),
 }
+
+############## Event bus producer ##############
+EVENT_BUS_PRODUCER_CONFIG = merge_producer_configs(EVENT_BUS_PRODUCER_CONFIG,
+                                                   ENV_TOKENS.get('EVENT_BUS_PRODUCER_CONFIG', {}))


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1346

## Description

This PR aims to add the changes made in upstream to our edx-platform repository in order for Event Bus to work with the Credly project integration. Changes add:

-  'openedx_events' to `INSTALLED_APPS` from LMS common settings.
- `EVENT_BUS_PRODUCER_CONFIG` definition and configuration for lms and cms.
-  `BADGES_ENABLED` feature to conditionally allow producing events defined within EVENT_BUS_PRODUCER_CONFIG setting.
- `EVENT_BUS_PRODUCER_CONFIG` to `KEYS_WITH_MERGED_VALUES`
- `merge_producer_config` to lms production settings to combine with any env settings if any.


## Changes made

Cherrypick the follwing commits from upstream https://github.com/openedx/edx-platform:
- https://github.com/openedx/edx-platform/pull/33392
- https://github.com/openedx/edx-platform/pull/33458
- https://github.com/openedx/edx-platform/pull/34749

## How to test?
### Config
- Add this configfuration to your lms/envs/devstack.py file : 
```bash
INSTALLED_APPS += ['debug_toolbar', 'edx_event_bus_redis']
EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
EVENT_BUS_REDIS_CONNECTION_URL = 'redis://:password@edx.devstack.redis:6379/'
EVENT_BUS_CONSUMER = 'edx_event_bus_redis.RedisEventConsumer'
EVENT_BUS_TOPIC_PREFIX = 'dev'
FEATURES['BADGES_ENABLED'] = True
```

### Consuming events

- Start consuming an event from another service. For that first install openedx-events  in your service with the version we are using, then add it to your IDA INSTALLED_APPS+='openedx_events', and set EVENT_BUS_CONSUMER, EVENT_BUS_REDIS_CONNECTION_URL, EVENT_BUS_TOPIC_PREFIX as the example above. Then run this command within this service container shell:
``` bash
 ./manage.py consume_events --topic course-status --group_id test_group --extra '{"consumer_name": "test_group.c1"}'
```
- checkout to this edx-platform branch in devstack.

### Produce event

- In your lms shell run this command : 
``` bash
./manage.py lms produce_event --signal openedx_events.learning.signals.COURSE_PASSING_STATUS_UPDATED --topic course-status --key-field user.id --data '{"course_passing_status": {"is_passing": true, "user": {"pii": {"username": "testuser", "email": "testuser@example.com", "name": "Test User"}, "id": 123, "is_active": true}, "course": {"course_key": "course-v1:edX+DemoX+Demo_Course", "display_name": "Demo Course"}}}'

```
