### PR TITLE
chore: update py2neo version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -818,7 +818,7 @@ psutil==5.9.2
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.3
+py2neo==2021.2.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1093,7 +1093,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo==2021.2.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1034,7 +1034,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo==2021.2.4
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR updates the py2neo requirement to be able to build the openedx image using tutor.

## Changes made

- [x] Update from py2neo==2021.2.3 to py2neo==2021.2.4

## Notes:

- https://discuss.openedx.org/t/missing-py2neo-package-causing-build-issues-in-all-edx-platform-releases/11371
- https://discuss.openedx.org/t/error-no-matching-distribution-found-for-py2neo-2021-2-3/11631

## PR Reference

- https://github.com/openedx/edx-platform/pull/33468
