### PR TITLE
PADV-1511 - Add setting to store SAML IDP id values.

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -964,13 +964,7 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
                 setattr(model, field, provider_value)
 
         # Generate fullname only for IES IDP.
-        # We deliberately left these values hard-coded instead of using Django settings because
-        # it would force us to add custom settings to the edx platform code,
-        # which we try to avoid as we might lose track of that kind of setting.
-        ies_entity_ids = [
-            'https://iam-stage.pearson.com:443/auth/saml-idp-uid',
-            'https://iam.pearson.com:443/auth/saml-idp-uid',
-        ]
+        ies_entity_ids = getattr(settings, 'SAML_IES_ENTITIES_IDS', [])
         first_name = details.get('first_name')
         last_name = details.get('last_name')
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5312,3 +5312,17 @@ derived_collection_entry(
     "learning-badges-lifecycle",
     "enabled",
 )
+
+# IES SAML integration.
+# .. setting_name: SAML_IES_ENTITIES_IDS
+# .. setting_default: []
+# .. setting_example_value: ['https://my-idp-integration-uri-id']
+# .. setting_description: This configuration allows us to define the IDs of the IES entities, to perform certain actions to the SAML IES request only.
+#    adding a new step to SOCIAL_AUTH_PIPELINE (edx-platform/common/djangoapps/third_party_auth/settings.py)
+#    is not a feasible option, since we can't override the SOCIAL_AUTH_PIPELINE from the Django or other plugin configuration,
+#    so we decided to handle it this way and add the necessary logic, directly in the edx-platform code
+#    edx-platform/common/djangoapps/third_party_auth/pipeline.py
+#    We will define the requried values using our Tutor plugin.
+#    Entity ID docs:
+#    https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_SAML_IdP.html#add-and-enable-a-saml-identity-provider
+SAML_IES_ENTITIES_IDS = []


### PR DESCRIPTION
## Description:

This PR adds a new setting called: SAML_IES_ENTITIES_IDS to configure the values of the IES SAML IDP ids for stage and prod. Initially we avoided this approach, but due to some problems with the IES configuration, it is better to do it this way so that we can quickly change the values in case we need to change them.

## How to test:
- Set up a local SAML IDP, check this video about SAML and configuring a local IDP: https://youtu.be/1PoWSVtwheI
- Create a test account on the IDP, follow this: https://github.com/kenchan0130/docker-simplesamlphp?tab=readme-ov-file#customize-idp-users
- Remove the fullname attribute associated with the IDP user.
- Add the entity id uri to the list of: SAML_IES_ENTITIES_IDS
- In a private window, log in using the local IDP.
- You should be logged in automatically and the fullname attribute should be set to your provided name + last name.

## Notes:

We will store the actual values using the Tutor Plugin.

## Reviewers:

- [ ] @anfbermudezme 
