### PR TITLE
PADV-1556 Create custom form for registration extra fields.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -298,13 +298,18 @@ class AccountCreationForm(forms.Form):
 
 def get_registration_extension_form(*args, **kwargs):
     """
-    Convenience function for getting the custom form set in settings.REGISTRATION_EXTENSION_FORM.
+    Convenience function for getting the custom form set in site configurations or plataform settings
+    REGISTRATION_EXTENSION_FORM.
 
-    An example form app for this can be found at http://github.com/open-craft/custom-form-app
+    Documentation on how to enable this feature can be found on
+    https://github.com/Pearson-Advance/pearson-core/blob/master/docs/pearson_core_features.md#amazon-custom-registration-form
     """
-    if not getattr(settings, 'REGISTRATION_EXTENSION_FORM', None):
+    # No Default valued is passed since we prioritize site configurations over site settings.
+    registration_extra_form = configuration_helpers.get_value('REGISTRATION_EXTENSION_FORM',
+                                                              settings.REGISTRATION_EXTENSION_FORM)
+    if not registration_extra_form:
         return None
-    module, klass = settings.REGISTRATION_EXTENSION_FORM.rsplit('.', 1)
+    module, klass = registration_extra_form.rsplit('.', 1)
     module = import_module(module)
     return getattr(module, klass)(*args, **kwargs)
 


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1556

## Description
Change REGISTRATION_EXTENSION_FORM platform setting and turns it into a site awareness feature

## Changes Made

- [x] Make REGISTRATION_EXTENSION_FORM site awareness by pulling it from configuration_helpers instead of platform settings

## How To Test
This feature could be fully tested along with https://github.com/Pearson-Advance/pearson-core/pull/53 

Nonetheless, you could follow the next steps to test it into the platform:

- Simply set the REGISTRATION_EXTENSION_FORM key into the the site configurations of a enabled site into your edx-platform instance with a string based value
- Place a debugger and/or print statement of its value 
- Access to the registration form of the affected site and confirms that the setting is being pulled 