### PR TITLE
fix: courseware-chromeless.html iframe height

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -121,14 +121,15 @@ ${HTML(fragment.foot_html())}
     // document loads, window resizes, or DOM mutates.
     if (window !== window.parent) {
       document.body.className += ' view-in-mfe';
-      var lastHeight = window.offsetHeight;
+      const extraHeight = 250;  // Set extra height value.
+      var lastHeight = window.offsetHeight + extraHeight; // Add extra height to avoid clipping.
       var lastWidth = window.offsetWidth;
       var contentElement = document.getElementById('content');
 
       function dispatchResizeMessage(event) {
         // Note: event is actually an Array of MutationRecord objects when fired from the MutationObserver
         var isLoadEvent = event.type === 'load';
-        var newHeight = contentElement.offsetHeight;
+        var newHeight = contentElement.offsetHeight + extraHeight;  // Add extra height to avoid clipping.
         var newWidth = contentElement.offsetWidth;
         if (!isLoadEvent && newWidth === lastWidth && newHeight === lastHeight) {
             // Monitor when any anchor tag is clicked, it is checked to make sure


### PR DESCRIPTION
## Description

This PR adds a fix to the courseware-chromeless.html template, this template is used to render the XBlock on the learning MFE in an Iframe, this template contains a JavaScript code that sends a postMessage to the parent window that is used by the learning MFE to resize the Iframe to the heigth of its content, on the initial load of the Iframe the height is incorrectly calculated when the maintenance banner is added to the unit content, to fix this an extra 250px is added to the calculated height of the Iframe.
