### PR TITLE
PADV 1684 - Add feature flag for LLM summarize for frontend

### DIFF
--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -7,6 +7,7 @@ import json
 
 from django.conf import settings
 from xblock.exceptions import NoSuchServiceError
+from openedx.core.djangoapps.plugins.plugins_hooks import run_extension_point
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
 from common.djangoapps.student.auth import is_ccx_course
@@ -50,6 +51,8 @@ def edxnotes(cls):
         except NoSuchServiceError:
             user = None
 
+        is_llm_summarize_enabled = run_extension_point('PEARSON_CORE_ENABLE_LLM_SUMMARIZE', course_id=str(course.id))
+
         if is_studio or not is_feature_enabled(course, user):
             return original_get_html(self, *args, **kwargs)
         else:
@@ -69,6 +72,10 @@ def edxnotes(cls):
                     "endpoint": get_public_endpoint(),
                     "debug": settings.DEBUG,
                     "eventStringLimit": settings.TRACK_MAX_EVENT / 6,
+                    "llmSummarize": {
+                        "isEnabled": is_llm_summarize_enabled,
+                        "courseId": str(course.id),
+                    },
                 },
             })
 

--- a/lms/static/js/edxnotes/plugins/llm_summarize.js
+++ b/lms/static/js/edxnotes/plugins/llm_summarize.js
@@ -87,17 +87,17 @@
                 let annotator = this.annotator;
                 document.head.appendChild(style);
                 this.modifyDom(this.annotator);
-
+                annotator.editor.options.llmSummarize = annotator.options.llmSummarize
                 const summarizeButton = document.getElementById('summarizeButton');
 
                 summarizeButton.addEventListener('click', function(ev) {
-                    annotator.editor.element[0].setAttribute('is_summarizing', true);
+                    annotator.editor.options.isSummarizing = true;
                 });
                 annotator.subscribe('annotationEditorShown', this.handleSummarize);
                 annotator.subscribe('annotationEditorHidden', this.cleanupSummarize);
             },
             handleSummarize: function (editor, annotation) {
-                if (editor.element[0].getAttribute('is_summarizing') !== 'true') return;
+                if (!editor.options || !editor.options.isSummarizing) return;
 
                 function toggleLoader() {
                     const saveButton = document.querySelector('.annotator-controls .annotator-save');
@@ -115,6 +115,7 @@
                     },
                     body: JSON.stringify({
                         text_to_summarize: annotation.quote,
+                        course_id: editor.options && editor.options.llmSummarize && editor.options.llmSummarize.courseId,
                     }),
                 });
 
@@ -140,7 +141,7 @@
 
                 textAreaWrapper.children[0].value = '';
                 textAreaWrapper.children[1].value = '';
-                editor.element[0].setAttribute('is_summarizing', 'false');
+                editor.options.isSummarizing = false;
                 loaderWrapper.classList.add('d-none');
             },
             modifyDom: function(annotator) {

--- a/lms/static/js/edxnotes/views/notes_factory.js
+++ b/lms/static/js/edxnotes/views/notes_factory.js
@@ -51,7 +51,11 @@
                         destroy: '/annotations/:id/',
                         search: '/search/'
                     }
-                }
+                },
+                llmSummarize: {
+                    isEnabled: params && params.llmSummarize && params.llmSummarize.isEnabled,
+                    courseId: params && params.llmSummarize && params.llmSummarize.courseId,
+                },
             };
         };
 
@@ -85,6 +89,9 @@
                 logger = NotesLogger.getLogger(element.id, params.debug),
                 annotator;
 
+            if (options && options.llmSummarize && options.llmSummarize.isEnabled) {
+                plugins.push('LlmSummarize');
+            }
             annotator = $el.annotator(options).data('annotator');
             setupPlugins(annotator, plugins, options);
             NotesCollector.storeNotesRequestData(


### PR DESCRIPTION
## Related tickets
https://github.com/Pearson-Advance/pearson-core/tree/vue/PADV-1684

## Original PR
https://github.com/Pearson-Advance/edx-platform/pull/131

## Description:
This PR is part of the AI assistance project and aims to add the connection to the summarize backend to the annotator js llm_summarize plugin. The plugin sends a request to pearson core summarize api and replaces the annotation text area value with the summary.

## How to test:
- Setup devstack and pull changes.
- Setup edx notes api service.
- Setup Pearson core plugin
- Follow instructions to enable LLM summarize endpoint in pearson core.
- Enable the waffle switch 'pearson_core.llm_summarize.enable_llm_summarize'
- On studio, select a course, go to advance settings, and on the 'other course settings field' put the following JSON:
```json
{
  "llm_summarize": {
    "is_enabled": true
  }
}
```
- Select a text inside a text or HTML block.
- Click on the summarize button.
- A loader should appear indicating that the content is being summarized.
- Now disable the switch or the other course settings, either way, the summarize button should not appear now.

## Reviewers:

- [ ] @alexjmpb 
- [ ] @Squirrel18   
