### PR TITLE
PADV 1853 - Fix LLM summarize feature flag not working

### DIFF
--- a/lms/static/js/edxnotes/views/notes_factory.js
+++ b/lms/static/js/edxnotes/views/notes_factory.js
@@ -10,7 +10,7 @@
         'js/edxnotes/plugins/search_override',
         'js/edxnotes/plugins/llm_summarize',
     ], function($, _, Annotator, NotesLogger, NotesCollector) {
-        var plugins = ['Auth', 'Store', 'Scroller', 'Events', 'Accessibility', 'CaretNavigation', 'Tags', 'LlmSummarize'],
+        var plugins = ['Auth', 'Store', 'Scroller', 'Events', 'Accessibility', 'CaretNavigation', 'Tags'],
             getOptions, setupPlugins, getAnnotator;
 
     /**


### PR DESCRIPTION
## Description

The llm_summarize plugin was added again in a conflict as a default plugin of annotatorjs, this causes that the plugin cannot be activated or deactivated. This PR aims to fix this issue
