### PR TITLE
fix: truncate the display_name field to a maximum 255 characters

### DIFF
--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -119,7 +119,7 @@ def _update_xblocks_cache(course_key):
         paths = _paths_from_data(block_data['paths'])
         if block_cache.display_name != block_data['display_name'] or not paths_equal(block_cache.paths, paths):
             log.info('Updating XBlockCache with usage_key: %s', str(block_cache.usage_key))
-            block_cache.display_name = block_data['display_name']
+            block_cache.display_name = block_data['display_name'][:255]
             block_cache.paths = paths
             block_cache.save()
 
@@ -136,7 +136,7 @@ def _update_xblocks_cache(course_key):
             log.info('Creating XBlockCache with usage_key: %s', str(block_data['usage_key']))
             block_cache, created = XBlockCache.objects.get_or_create(usage_key=block_data['usage_key'], defaults={
                 'course_key': course_key,
-                'display_name': block_data['display_name'],
+                'display_name': block_data['display_name'][:255],
                 'paths': paths,
             })
 


### PR DESCRIPTION
## Description
This PR amis to truncate `display_name` field to prevent the following error:
`django.db.utils.DataError: (1406, "Data too long for column 'display_name' at row 1")` 
This error occurs when attempting to create or update an `XBlockCache`.

## Testing instructions

Create a course with Blank Common Problem and set the following name: 
`Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Duplicate of 'Blank Common Problem''''''''''''''''`

From a cms shell, run the following code:
```
from openedx.core.djangoapps.bookmarks.tasks import update_xblocks_cache
update_xblocks_cache(<course-id>)
```
And the xblock cached should be created sucessfully

