### PR TITLE
PADV-2086 Allow username field to be shown on SAML registration process

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -298,18 +298,14 @@ class AccountCreationForm(forms.Form):
 
 def get_registration_extension_form(*args, **kwargs):
     """
-    Convenience function for getting the custom form set in site configurations or plataform settings
-    REGISTRATION_EXTENSION_FORM.
+    Convenience function for getting the custom form set in settings.REGISTRATION_EXTENSION_FORM.
 
-    Documentation on how to enable this feature can be found on
-    https://github.com/Pearson-Advance/pearson-core/blob/master/docs/pearson_core_features.md#amazon-custom-registration-form
+    An example form app for this can be found at http://github.com/open-craft/custom-form-app
     """
-    # No Default valued is passed since we prioritize site configurations over site settings.
-    registration_extra_form = configuration_helpers.get_value('REGISTRATION_EXTENSION_FORM',
-                                                              settings.REGISTRATION_EXTENSION_FORM)
-    if not registration_extra_form:
+    if not getattr(settings, 'REGISTRATION_EXTENSION_FORM', None):
         return None
-    module, klass = registration_extra_form.rsplit('.', 1)
+
+    module, klass = settings.REGISTRATION_EXTENSION_FORM.rsplit('.', 1)
     module = import_module(module)
     return getattr(module, klass)(*args, **kwargs)
 
@@ -1142,6 +1138,12 @@ class RegistrationFormFactory:
                             current_provider.skip_registration_form and enterprise_customer_for_request(request)
                         ) or current_provider.sync_learner_profile_data
                     )
+
+                    if (hide_registration_fields_except_tos and
+                        current_provider.slug in configuration_helpers.get_value(
+                            'SSO_SLUG_REGISTRATION_USERNAME_REQUIRED', [],
+                        )):
+                        field_overrides['username'] = None
 
                     for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
                         if field_name in field_overrides:


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2086

## Description

This PR allows the sites to request the username field when a SSO or third party auth integration is set. This is allowed by overriding the username value to None so in that way the workflow won't apply the `hidden` property to the field in registration form. 

## Changes Made

[x] Change third_party_authvalidation workflow to set "None" whatever the third part auth system is sending into the username during the registration process
[x] This PR also removes the changes made in this PR https://github.com/Pearson-Advance/edx-platform/pull/129/files

## How To Test

1. Set up a valid SAML IdP in your workspace, set up your devstack instance following the openedx guide https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/index.html
2. Save the Display Name you've set to the IdP
3. Set the `SSO_REGISTRATION_USERNAME_REQUIRED` site configuration with a list containing the Display Name of the IdP that would be impacted for this feature. 
![image](https://github.com/user-attachments/assets/ad1e8047-40ab-45d2-be43-f8e3949857f7)

4. Confirms that when you try to register a new user via SSO it would shown the field during registration process

![image](https://github.com/user-attachments/assets/8d2c63ef-e56d-4087-b9a5-b5fade80351f)


