### PR TITLE
PADV 1997 - Change site domain

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -773,14 +773,14 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     # for backwards compatibility.
     if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
         urlpatterns += [
-            re_path(r'^admin_ops/auth/user/\d+/password/$', handler404),
+            re_path(r'^ops_admin/auth/user/\d+/password/$', handler404),
         ]
     urlpatterns += [
-        path('admin_ops/password_change/', handler404),
+        path('ops_admin/password_change/', handler404),
         # We are enforcing users to login through third party auth in site's
         # login page so we are disabling the admin panel's login page.
-        path('admin_ops/login/', redirect_to_lms_login),
-        path('admin_ops/', admin.site.urls),
+        path('ops_admin/login/', redirect_to_lms_login),
+        path('ops_admin/', admin.site.urls),
     ]
 
 if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -773,14 +773,14 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     # for backwards compatibility.
     if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
         urlpatterns += [
-            re_path(r'^admin/auth/user/\d+/password/$', handler404),
+            re_path(r'^admin_ops/auth/user/\d+/password/$', handler404),
         ]
     urlpatterns += [
-        path('admin/password_change/', handler404),
+        path('admin_ops/password_change/', handler404),
         # We are enforcing users to login through third party auth in site's
         # login page so we are disabling the admin panel's login page.
-        path('admin/login/', redirect_to_lms_login),
-        path('admin/', admin.site.urls),
+        path('admin_ops/login/', redirect_to_lms_login),
+        path('admin_ops/', admin.site.urls),
     ]
 
 if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -687,7 +687,7 @@ def redirect_to_lms_login(request):
     This view redirect the admin/login url to the site's login page if
     waffle switch is on otherwise returns the admin site's login view.
     """
-    return redirect('/login?next=/admin')
+    return redirect('/login?next=/ops_admin')
 
 
 class LoginSessionView(APIView):


### PR DESCRIPTION
## Related PR

https://agile-jira.pearson.com/browse/PADV-1997

## Description

This PR aims to change the default django admin path to /ops_admin in order to avoid conflicts with the certprep manager MFE new route /admin.