### PR TITLE
PADV-2022 set STUDENT_FILEUPLOAD_MAX_SIZE via site configurations

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -45,6 +45,7 @@ from xblock.runtime import KvsFieldData
 from lms.djangoapps.badges.service import BadgingService
 from lms.djangoapps.badges.utils import badges_enabled
 from lms.djangoapps.teams.services import TeamsService
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.xblock_services.call_to_action import CallToActionService
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError, ProcessingError
@@ -1203,6 +1204,11 @@ def _check_files_limits(files):
 
     Returns None if files are correct or an error messages otherwise.
     """
+    student_fileupload_max_size = configuration_helpers.get_value(
+        'STUDENT_FILEUPLOAD_MAX_SIZE',
+        settings.STUDENT_FILEUPLOAD_MAX_SIZE,
+    )
+
     for fileinput_id in files.keys():
         inputfiles = files.getlist(fileinput_id)
 
@@ -1214,9 +1220,9 @@ def _check_files_limits(files):
 
         # Check file sizes
         for inputfile in inputfiles:
-            if inputfile.size > settings.STUDENT_FILEUPLOAD_MAX_SIZE:  # Bytes
+            if inputfile.size > student_fileupload_max_size:  # Bytes
                 msg = 'Submission aborted! Your file "%s" is too large (max size: %d MB)' % \
-                      (inputfile.name, settings.STUDENT_FILEUPLOAD_MAX_SIZE / (1000 ** 2))
+                      (inputfile.name, student_fileupload_max_size / (1000 ** 2))
                 return msg
 
     return None


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2022

## Description

This PR adds the feature to set via site configurations the maximum file size to be accepted for the attachments to be uploaded by a Xblock handler. If not limit has been set, it would take the one set by the platform as it used to do.

## Changes Made

[x] Pull the STUDENT_FILEUPLOAD_MAX_SIZE site configurations and checks if the file size metts the criteria
[x] Set the file size defined either by site configurations or platform setting


## How To Test

1. Set the site configuration as `STUDENT_FILEUPLOAD_MAX_SIZE': 1400000000` where 1400000000 is a byte expressed value of the desire max size. In this case is ~1.4GB. 
2. Confirms that the platform allows upload files with a size less than the defined 1.4GB limit and it only impacts for the Xblock mentioned.

This has been made in order to cover the [edx-sga PR#13](https://github.com/Pearson-Advance/edx-sga/pull/13) so [upload_assignment](https://github.com/Pearson-Advance/edx-sga/blob/pearson-release/olive.main/edx_sga/sga.py#L252) is the handler to be impacted by this.