### PR TITLE
PADV-2127 - Add SessionJWTCreationRequested filter call.

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -11,6 +11,8 @@ from edx_rbac.utils import create_role_auth_claim_for_user
 from jwkest import jwk
 from jwkest.jws import JWS
 
+from openedx_filters.authentication.filters import SessionJWTCreationRequested
+
 from common.djangoapps.student.models import UserProfile, anonymous_id_for_user
 
 log = logging.getLogger(__name__)
@@ -182,6 +184,7 @@ def _create_jwt(
     }
     payload.update(additional_claims or {})
     _update_from_additional_handlers(payload, user, scopes)
+    payload, user = SessionJWTCreationRequested.run_filter(payload=payload, user=user)
     role_claims = create_role_auth_claim_for_user(user)
     if role_claims:
         payload['roles'] = role_claims


### PR DESCRIPTION
## Description

This PR adds a new filter that updates the JWT token's payload of a User by adding extra data when its creation is requested. The filter receives the payload and the User object, and returns the User and the modified payload with any new data included. For example: adds a new field with the permission roles of a certain subproject. Other uses could include: adding the last access datetime of the User, a status, or any other useful information related to the User.

For this particular change, the call of the filter is implemented in the `_create_jwt` method when requesting the corresponding token.
