### PR TITLE
PADV-2235 fix: CSS style to email templates to make them compatible with email."

### DIFF
--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -3,11 +3,12 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
-    <tr>
-        <td style="width: 100%;
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8; width: 100%;">
+        <tr>
+            <td style="
+            width: 100%;
             max-width: 800px;
-            background-image: url(https://pearson-production-media.s3.amazonaws.com/IPbackground.svg);
+            background-image: url(https://partner-courses.pearson.com/static/pearson-theme/images/IPbackground.svg);
             background-repeat: no-repeat;
             background-position: right center;
             padding-bottom: 40px;
@@ -16,7 +17,7 @@
             margin: auto;
             text-align: center;
             padding: 20px;
-            ">
+        ">
 
             <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; display: inline !important;" />
 
@@ -30,7 +31,11 @@
                         ">
 
                 <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
-                    {% blocktrans %}You have been invited to join to <br/> {{ course_name }} <br/> {{ class_name }}{% endblocktrans %}
+                    {% if class_name != none %}
+                        You have been invited to join to <br/> {{ course_name }} <br/> {{ class_name }}
+                    {% else %}
+                        You have been invited to join to <br/> {{ course_name }}
+                    {% endif %}
                 </h1>
                 <p style="padding: 0px;
                           width: 50%;

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -3,11 +3,12 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
-   <tr>
-        <td style="width: 100%;
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8; width: 100%;">
+        <tr>
+            <td style="
+            width: 100%;
             max-width: 800px;
-            background-image: url(https://pearson-production-media.s3.amazonaws.com/IPbackground.svg);
+            background-image: url(https://partner-courses.pearson.com/static/pearson-theme/images/IPbackground.svg);
             background-repeat: no-repeat;
             background-position: right center;
             padding-bottom: 40px;
@@ -16,7 +17,7 @@
             margin: auto;
             text-align: center;
             padding: 20px;
-            ">
+        ">
             <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; display: inline !important;" />
 
             <div style="width: 90%;

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -63,8 +63,7 @@
         font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-size: 1em;
         line-height: 1.5;
-        max-width: 600px;
-        padding: 0 20px 0 20px;
+        padding: 0 50px 0 20px;
     ">
         <tr>
             <!-- HEADER -->
@@ -152,6 +151,7 @@
       style="
       padding: 15px 20px 30px 20px;
       box-shadow: 0 1px 5px rgba(0,0,0,0.25);
+      width: 100%;
       "
     {% endblock %}
   >


### PR DESCRIPTION
### Description
This pull request updates the login button alignment and layout in email templates to ensure proper rendering across all major email clients. The button is now consistently aligned to the right using a table-based layout, which improves compatibility especially in clients like Gmail and Outlook. Additionally, inline styles were preserved and refined to match the existing branding and accessibility standards.

### Changes Made

- Refactored the Log In and Register buttons to use a table wrapper with align="right" for proper alignment in email clients.
- Removed reliance on text-align inside <td> and instead used table layout for safer positioning.
- Ensured inline styles maintain the original visual appearance, including background color, padding, and font styles.

