### PR TITLE
PADV-2313 fix: Import a new .png background image to the enroll email

### DIFF
--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -8,7 +8,7 @@
             <td style="
             width: 100%;
             max-width: 800px;
-            background-image: url(https://partner-courses.pearson.com/static/pearson-theme/images/IPbackground.svg);
+            background-image: url('{% static "pearson-theme/images/IPbackground.png" %}');
             background-repeat: no-repeat;
             background-position: right center;
             padding-bottom: 40px;
@@ -18,7 +18,6 @@
             text-align: center;
             padding: 20px;
         ">
-
             <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; display: inline !important;" />
 
             <div style="width: 90%;

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -8,7 +8,7 @@
             <td style="
             width: 100%;
             max-width: 800px;
-            background-image: url(https://partner-courses.pearson.com/static/pearson-theme/images/IPbackground.svg);
+            background-image: url('{% static "pearson-theme/images/IPbackground.png" %}');
             background-repeat: no-repeat;
             background-position: right center;
             padding-bottom: 40px;

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -18,6 +18,9 @@
   p, td {
     font-family: 'Roboto', sans-serif;
   }
+  table{
+    width: 100% !important;
+  }
 </style>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Description

This PR introduces a new background image (`IPbackground.png`) to be used in enrollment notification emails. The previous image, an `.svg`, was not rendering correctly across several email clients — especially Gmail — due to limited support for vector images in HTML emails.

To ensure better compatibility and consistent branding, the `.svg` has been replaced by a `.png` version of the same asset, hosted in the same static path.

## Changes Made

- [x] Replaced `IPbackground.svg` with `IPbackground.png` in the static assets from themes.
- [x] Updated email template styles to reference the new PNG file.

## How to test

- Install and configure openedx-themes (if you don't have it):
  -  Clone the openedx-themes repository into the same directory where the src folder is located.
  - Switch to this branch of the themes repository:
    - https://github.com/Pearson-Advance/openedx-themes/pull/276 
  - Open the LMS shell.
  - Navigate to edx/etc.
  - Edit the lms.yml file and add the following configuration:
    - ENABLE_COMPREHENSIVE_THEMING: tru
    - COMPREHENSIVE_THEME_DIRS:
      - '/edx/app/edx-themes/edx-platform'
  - Then, go to http://localhost:18000/admin/.
  - Look for "Site themes" to add a new entry.

- check the next steps to test the email template in: 
- https://github.com/Pearson-Advance/edx-platform/pull/153

<img src="https://github.com/user-attachments/assets/99517f88-9cec-4066-8f16-98cb20371920" alt="image" style="height: 200px;" />



