### PR TITLE
fix: Import a new .png background image to the enroll email

### DIFF
--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -4,92 +4,66 @@
 {% load static %}
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8; width: 100%;">
-        <tr>
-            <td style="
-            width: 100%;
-            max-width: 800px;
-            background-image: url('https://pearson-production-media.s3.us-east-1.amazonaws.com/backgroundIP.png');
-            background-repeat: no-repeat;
-            background-position: right center;
-            padding-bottom: 40px;
-            color: #000000;
-            background-size: cover;
-            margin: auto;
-            text-align: center;
-            padding: 20px;
-        ">
-            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; display: inline !important;" />
+    <tr>
+        <td style="width: 100%; max-width: 800px; margin: auto; text-align: center; padding: 0; position: relative;">
 
-            <div style="width: 90%;
-                        text-align: left;
-                        padding: 2% 5%;
-                        background-size: 50%;
-                        background-position: right bottom;
-                        background-repeat: no-repeat;
-                        padding-bottom: 35%;
-                        ">
+            <!-- Background image -->
+            <img src="https://pearson-production-media.s3.us-east-1.amazonaws.com/backgroundIP.png"
+                 alt=""
+                 width="100%"
+                 height="auto"
+                 style="display: block; width: 100%; height: auto;" />
 
-                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
-                    {% if class_name != none %}
-                        You have been invited to join to <br/> {{ course_name }} <br/> {{ class_name }}
+            <!-- Overlay content -->
+            <div style="position: absolute; top: 0; left: 0; width: 100%; padding: 20px; box-sizing: border-box;">
+
+                <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png"
+                     style="width: 150px; padding: 5px; display: inline !important;" />
+
+                <div style="width: 90%;
+                            text-align: left;
+                            padding: 2% 5%;
+                            padding-bottom: 35%;">
+
+                    <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                        {% if class_name != none %}
+                            You have been invited to join to <br/> {{ course_name }} <br/> {{ class_name }}
+                        {% else %}
+                            You have been invited to join to <br/> {{ course_name }}
+                        {% endif %}
+                    </h1>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% filter force_escape %}
+                        {% blocktrans %}You have been invited to join a class by the course staff at {{ institution_name }}.{% endblocktrans %}
+                        {% endfilter %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% blocktrans with date=class_start_date %}Your class begins on: <strong>{{ date }}</strong>.{% endblocktrans %}
+                    </p>
+
+                    {% if is_shib_course %}
+                        {% if auto_enroll %}
+                            <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                                {% filter force_escape %}
+                                {% blocktrans %}To access this course click on the button below and log in.{% endblocktrans %}
+                                {% endfilter %}
+                            </p>
+                            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_url %}
+                        {% elif course_about_url is not None %}
+                            <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                                {% filter force_escape %}
+                                {% blocktrans %}To access this course visit it and register:{% endblocktrans %}
+                                {% endfilter %}
+                            </p>
+                            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
+                        {% endif %}
                     {% else %}
-                        You have been invited to join to <br/> {{ course_name }}
-                    {% endif %}
-                </h1>
-                <p style="padding: 0px;
-                          width: 50%;
-                          min-width: 300px;
-                          margin-top: 20px;
-                          ">
-                    {% filter force_escape %}
-                    {% blocktrans %}You have been invited to join a class by the course staff at {{ institution_name }}.{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    {% blocktrans with date=class_start_date %}Your class begins on: <strong>{{ date }}</strong>.{% endblocktrans %}
-                    <br />
-                    <br />
-
-                </p>
-
-                {% if is_shib_course %}
-                {% if auto_enroll %}
-                    <p style="padding: 0px;
-                            width: 50%;
-                            min-width: 300px;
-                            margin-top: 20px;
-                            ">
-                        {% filter force_escape %}
-                        {% blocktrans %}To access this course click on the button below and log in.{% endblocktrans %}
-                        {% endfilter %}
-                        <br />
-                    </p>
-
-                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_url %}
-                {% elif course_about_url is not None %}
-                    <p style="padding: 0px;
-                            width: 50%;
-                            min-width: 300px;
-                            margin-top: 20px;
-                            ">
-                        {% filter force_escape %}
-                        {% blocktrans %}To access this course visit it and register:{% endblocktrans %}
-                        {% endfilter %}
-                        <br />
-                    </p>
-
-                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
-                {% endif %}
-                {% else %}
-                <p style="padding: 0px;
-                            width: 50%;
-                            min-width: 300px;
-                            margin-top: 20px;
-                            ">
+                        <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
                             <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
                                 {% blocktrans with email=email_address %}
-                                Please follow these instructions to complete your registration:
+                                    Please follow these instructions to complete your registration:
                                 {% endblocktrans %}
                             </p>
                             <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px; margin-left:20px;">
@@ -113,35 +87,28 @@
                             <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
                                 {% trans "The Pearson Team" %}
                             </p>
-                    <br />
-                </p>
-                {# xss-lint: disable=django-trans-missing-escape #}
-                {% trans "Create your Pearson Account" as button_cta_text %}
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=button_cta_text course_cta_url=registration_url %}
+                        <br />
+                        {% trans "Create your Pearson Account" as button_cta_text %}
+                        {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=button_cta_text course_cta_url=registration_url %}
 
-                <p style="padding: 0px;
-                            width: 50%;
-                            min-width: 300px;
-                            margin-top: 20px;
-                            ">
-                    {% if auto_enroll %}
-                    {% filter force_escape %}
-                    {% blocktrans %}Once you have registered and activated your account, you will see {{ class_name }} listed on your dashboard.{% endblocktrans %}
-                    {% endfilter %}
-                    {% elif course_about_url is not None %}
-                    {% filter force_escape %}
-                    {% blocktrans %}Once you have registered and activated your account, you will be able to access this course:{% endblocktrans %}
-                    {% endfilter %}
-                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
-                    {% else %}
-                    {% filter force_escape %}
-                    {% blocktrans %}You can then enroll in {{ course_name }}.{% endblocktrans %}
-                    {% endfilter %}
+                        <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                            {% if auto_enroll %}
+                                {% filter force_escape %}
+                                {% blocktrans %}Once you have registered and activated your account, you will see {{ class_name }} listed on your dashboard.{% endblocktrans %}
+                                {% endfilter %}
+                            {% elif course_about_url is not None %}
+                                {% filter force_escape %}
+                                {% blocktrans %}Once you have registered and activated your account, you will be able to access this course:{% endblocktrans %}
+                                {% endfilter %}
+                                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
+                            {% else %}
+                                {% filter force_escape %}
+                                {% blocktrans %}You can then enroll in {{ course_name }}.{% endblocktrans %}
+                                {% endfilter %}
+                            {% endif %}
+                        </p>
                     {% endif %}
-                    <br />
-                </p>
-                {% endif %}
-
+                </div>
             </div>
         </td>
     </tr>

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -4,75 +4,68 @@
 {% load static %}
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8; width: 100%;">
-        <tr>
-            <td style="
-            width: 100%;
-            max-width: 800px;
-            background-image: url('https://pearson-production-media.s3.us-east-1.amazonaws.com/backgroundIP.png');
-            background-repeat: no-repeat;
-            background-position: right center;
-            padding-bottom: 40px;
-            color: #000000;
-            background-size: cover;
-            margin: auto;
-            text-align: center;
-            padding: 20px;
-        ">
-            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; display: inline !important;" />
+    <tr>
+        <td style="width: 100%; max-width: 800px; margin: auto; text-align: center; padding: 0; position: relative;">
 
-            <div style="width: 90%;
-                        text-align: left;
-                        padding: 2% 5%;
-                        background-size: 50%;
-                        background-position: right bottom;
-                        background-repeat: no-repeat;
-                        padding-bottom: 35%;
-                        ">
+            <!-- Background Image as <img> -->
+            <img src="https://pearson-production-media.s3.us-east-1.amazonaws.com/backgroundIP.png"
+                 alt=""
+                 width="100%"
+                 height="auto"
+                 style="display: block; width: 100%; height: auto;" />
 
-                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
-                    {% if class_name != none %}
-                        You have been enrolled in <br/> {{ course_name }} <br/> {{ class_name }}
-                    {% else %}
-                        You have been enrolled in <br/> {{ course_name }}
-                    {% endif %}
-                </h1>
-                <p style="padding: 0px;
-                          width: 50%;
-                          min-width: 300px;
-                          margin-top: 20px;
-                          ">
-                    {% blocktrans %}You have been enrolled into a class by the course staff at {{ institution_name }}.{% endblocktrans %}
-                    <br />
-                </p>
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    {% blocktrans with date=class_start_date %}Your class begins on: <strong>{{ class_start_date }}</strong>.{% endblocktrans %}
-                    <br />
-                </p>
+            <!-- Overlay Content -->
+            <div style="position: absolute; top: 0; left: 0; width: 100%; padding: 20px; box-sizing: border-box;">
 
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    {% blocktrans with url=course_url %}
-                        <a href="{{ course_url }}" target="_blank">Login here!</a> to access your course materials.
-                    {% endblocktrans %}
-                </p>
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    <strong>New to Pearson Courses?</strong><br />{% trans "If you are new to Pearson Courses, you must first " %}
-                    {% blocktrans with url=new_domain_url email=email_address %}
-                    <a href="{{ registration_url }}" target="_blank">create your Pearson account</a><br />
-                    Be sure to use your enrolled email address <strong>{{ email }}</strong><br />when creating your account.
-                    {% endblocktrans %}
-                </p>
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    {% blocktrans with name=institution_name email=institution_admin_email %}
-                        If you have questions about this enrollment, please send an email to the administrator at {{ name }}:
-                        <a href="mailto:{{ institution_admin_email }}">{{ institution_admin_email }}</a>
-                    {% endblocktrans %}
-                </p>
-                <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
-                    {% trans "The Pearson Team" %}
-                </p>
-                {% trans "Access the Course Materials" as course_cta_text %}
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
+                <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png"
+                     style="width: 150px; padding: 5px; display: inline !important;" />
 
+                <div style="width: 90%; text-align: left; padding: 2% 5%; padding-bottom: 35%;">
+
+                    <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                        {% if class_name != none %}
+                            You have been enrolled in <br/> {{ course_name }} <br/> {{ class_name }}
+                        {% else %}
+                            You have been enrolled in <br/> {{ course_name }}
+                        {% endif %}
+                    </h1>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% blocktrans %}You have been enrolled into a class by the course staff at {{ institution_name }}.{% endblocktrans %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% blocktrans with date=class_start_date %}Your class begins on: <strong>{{ class_start_date }}</strong>.{% endblocktrans %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% blocktrans with url=course_url %}
+                            <a href="{{ course_url }}" target="_blank">Login here!</a> to access your course materials.
+                        {% endblocktrans %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        <strong>New to Pearson Courses?</strong><br />{% trans "If you are new to Pearson Courses, you must first " %}
+                        {% blocktrans with url=new_domain_url email=email_address %}
+                        <a href="{{ registration_url }}" target="_blank">create your Pearson account</a><br />
+                        Be sure to use your enrolled email address <strong>{{ email }}</strong><br />when creating your account.
+                        {% endblocktrans %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% blocktrans with name=institution_name email=institution_admin_email %}
+                            If you have questions about this enrollment, please send an email to the administrator at {{ name }}:
+                            <a href="mailto:{{ institution_admin_email }}">{{ institution_admin_email }}</a>
+                        {% endblocktrans %}
+                    </p>
+
+                    <p style="padding: 0px; width: 50%; min-width: 300px; margin-top: 20px;">
+                        {% trans "The Pearson Team" %}
+                    </p>
+
+                    {% trans "Access the Course Materials" as course_cta_text %}
+                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
+                </div>
             </div>
         </td>
     </tr>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -190,7 +190,8 @@
         <td>
           Copyright &copy; {% now "Y" %} {{ platform_name }}, {% trans "or its affiliate(s). All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
           <br/>
-          {% trans "For more information, visit:" as tmsg %}{{ tmsg | force_escape }}
+          {% trans "For more information, visit:" as tmsg %}{{ tmsg | force_escape }} <a href="https://www.pearsonvue.com/us/en/training-centers/skilling-suite.html
+">pearsonvue.com</a>
         </td>
       </tr>
       {% if unsubscribe_url %}


### PR DESCRIPTION
## Description

This PR introduces a new background image (`IPbackground.png`) to be used in enrollment notification emails, as a img tag and not by a ccs background-image prop.

To ensure better compatibility and consistent branding, the `.svg` has been replaced by a `.png` version of the same asset, hosted in the same static path.

## Changes Made

- [x] Updated email template styles to reference the new PNG file.

## How to test

- Install and configure openedx-themes (if you don't have it):
  -  Clone the openedx-themes repository into the same directory where the src folder is located.
  - Switch to this branch of the themes repository:
    - https://github.com/Pearson-Advance/openedx-themes/pull/276 
  - Open the LMS shell.
  - Navigate to edx/etc.
  - Edit the lms.yml file and add the following configuration:
    - ENABLE_COMPREHENSIVE_THEMING: tru
    - COMPREHENSIVE_THEME_DIRS:
      - '/edx/app/edx-themes/edx-platform'
  - Then, go to http://localhost:18000/admin/.
  - Look for "Site themes" to add a new entry.

- check the next steps to test the email template in: 
- https://github.com/Pearson-Advance/edx-platform/pull/153

<img src="https://github.com/user-attachments/assets/99517f88-9cec-4066-8f16-98cb20371920" alt="image" style="height: 200px;" />



