### PR TITLE
PADV-2314 fix: Modify styles to adapt the container of enroll email with the email client

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5210,7 +5210,7 @@ PERSONALIZED_RECOMMENDATION_COOKIE_NAME = 'edx-user-personalized-recommendation'
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: None
-ENABLE_MFE_CONFIG_API = True
+ENABLE_MFE_CONFIG_API = False
 
 # .. setting_name: MFE_CONFIG
 # .. setting_implementation: DjangoSetting
@@ -5326,13 +5326,3 @@ derived_collection_entry(
 #    Entity ID docs:
 #    https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_SAML_IdP.html#add-and-enable-a-saml-identity-provider
 SAML_IES_ENTITIES_IDS = []
-
-
-OPEN_EDX_FILTERS_CONFIG = {
-    "org.openedx.learning.course.enrollment.email-notification-extra-params.v1": {
-        "fail_silently": False,
-        "pipeline": [
-            "pearson_course_operation.pipeline.GetEnrollEmailNotificationExtraParameters",
-        ],
-    },
-}

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -18,9 +18,6 @@
   p, td {
     font-family: 'Roboto', sans-serif;
   }
-  table{
-    width: 100% !important;
-  }
 </style>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -63,6 +60,7 @@
 
     <!-- CONTENT -->
     <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f5f5" width="100%" style="
+        width: 100%;
         font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
         font-size: 1em;
         line-height: 1.5;
@@ -190,7 +188,8 @@
         <td>
           Copyright &copy; {% now "Y" %} {{ platform_name }}, {% trans "or its affiliate(s). All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
           <br/>
-          {% trans "For more information, visit:" as tmsg %}{{ tmsg | force_escape }}
+          {% trans "For more information, visit:" as tmsg %}{{ tmsg | force_escape }} <a href="https://www.pearsonvue.com/us/en/training-centers/skilling-suite.html
+">pearsonvue.com</a>
         </td>
       </tr>
       {% if unsubscribe_url %}


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2314

### **Description**
This PR includes  improvements to the email templates used in enrollment communications and deleting unnecessary configs (moved to pearson plugin) 

### **Changes**
- Ensures the main email container (<table>) uses width: 100% to properly adapt across email clients and prevent overflow or layout issues.

- Addresses layout inconsistencies caused by missing or unstyled containers, enhancing compatibility across clients like Gmail and Outlook.

- Adds a new informational link to the footer section:
https://www.pearsonvue.com/us/en/training-centers/skilling-suite.html
This link directs users to the Skilling Suite informational page for more context and support.

- Moving configs to pearson plugin

![image](https://github.com/user-attachments/assets/d407a6a9-e995-4be1-bc2c-ee5d637694bc)
