### PR TITLE
PADV-2314 fix: Modify styles to adapt the container of enroll email with the email client (recommended max-width approach).

### DIFF
--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -44,6 +44,8 @@
 <div bgcolor="#f5f5f5" lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
   padding: 0 20px;
   background-color: #f5f5f5;
+  max-width: 800px;
+  margin: auto;
   ">
   <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
   <!--[if mso]>


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2314

### **Description**
This PR applies a max-width to the content container to center the content.

### **Changes**
- Adds a max-width into the main container and applies a margin auto to center it.

- Addresses layout inconsistencies caused by missing or unstyled containers, enhancing compatibility across clients like Gmail and Outlook.

![image](https://github.com/user-attachments/assets/d407a6a9-e995-4be1-bc2c-ee5d637694bc)
