### PR TITLE
chore: change openedx-events constraint to private repository

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -100,4 +100,4 @@ pytz==2022.2.1
 
 # openedx-events>0.13.0 causes test failures due to breaking changes
 # These broken tests will be fixed in a separate PR
-openedx-events==9.10.0
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0#egg=openedx-events

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -761,7 +761,7 @@ openedx-calc==3.0.1
     # via -r requirements/edx/base.in
 openedx-django-pyfs==3.2.1
     # via xblock
-openedx-events==9.10.0
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0#egg=openedx-events
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -991,7 +991,7 @@ openedx-django-pyfs==3.2.1
     # via
     #   -r requirements/edx/testing.txt
     #   xblock
-openedx-events==9.10.0
+openedx-events @ git+https://github.com/Pearson-Advance/openedx-events.git@v9.10.0#egg=openedx-events
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2388

## Description

This PR Replaces the constraint for the `openedx-events` package dependency to our private repository.

## Changes Made

- [x] Replaces `openedx-events` constraint dependency

## Changes required in local instances:

1. Please clone the [Pearson-advance/openedx-events](https://github.com/Pearson-Advance/openedx-events/) repository inside your `src` folder of Devstack instance
2. Please go inside of a LMS shell via make `lms-shell` and perform the following commands
3. `pip uninstall openedx-events`
4. `pip install -e /edx/src/openedx-events`

