### PR TITLE
PADV-2736 feat: adding custom registration extension point and custom email templates

### DIFF
--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -62,8 +62,8 @@ def inactive_user_view(request):
             user.is_active = True
             user.save()
             activated = True
-    if not activated:
-        compose_and_send_activation_email(user, profile)
+    # if not activated:
+    compose_and_send_activation_email(user, profile)
 
     request_params = request.GET
     redirect_to = request_params.get('next')

--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
 {% if route_enabled %}
     <tr>
         <td>
@@ -18,51 +18,46 @@
     </tr>
 {% endif %}
     <tr>
-        <td>
-            <h1>
-                {% trans "Account activation" as header_msg %}{{ header_msg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}You're almost there! Use the link below to activate your account to access engaging, high-quality {{ platform_name }} courses. Note that you will not be able to log back into your account until you have activated it.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Activate your account{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-        </td>
-    </tr>
-        <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans trimmed asvar assist_msg %}
-                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ support_email }}{end_anchor}.
-                {% endblocktrans %}
-                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
-                <br />
-            </p>
-        </td>
-    <tr>
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
 
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700; font-size: 1.7em; margin-top: 30px; margin-bottom: 20px;">
+                    {% trans "You're Nearly Signed Up" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}To validate your new account, please click on the Validate Account button below.{% endblocktrans %}
+                    <br />
+                </p>
+
+                {% trans "Validate Account" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
+            </div>
+        </td>
     </tr>
-    <tr>
+    <tr style="background-color: #FFF;">
         <td>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                    {% blocktrans %}This email message was automatically sent by {{ lms_url }} because someone attempted to create an account on {{ platform_name }} using this email address.{% endblocktrans %}
-                {% endfilter %}
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
+                {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/common/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.html
@@ -3,42 +3,45 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
-        <td>
-            <h1>
-                {% trans "Create Password" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}We've restored access to your {{ platform_name }} account using the recovery email you provided at registration.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Once you've created a password [below], you will be able to log in to {{ platform_name }} with this email ({{ email }}) and your new password.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." as tmsg %}{{ tmsg | force_escape }}
-                <br />
-            </p>
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700; font-size: 1.7em; margin-top: 30px; margin-bottom: 20px;">
+                    {% trans "Create Password" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ site_name }}. If you didn't request this change, you can disregard this email - we have not yet created your password.{% endblocktrans %}
+                    <br />
+                </p>
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Create Password{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+                 {% trans "Create my Password" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
+
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+
+            </div>
         </td>
     </tr>
 </table>

--- a/common/templates/student/edx_ace/emailchange/email/body.html
+++ b/common/templates/student/edx_ace/emailchange/email/body.html
@@ -3,31 +3,55 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
+
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                    {% trans "Email Change" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% if is_secondary_email_change_request %}
+                    {% blocktrans %}We received a request to change the secondary e-mail associated with your {{ site_name }} account to {{ new_email }}. If this is correct, please click below to confirm your new secondary e-mail address. {% endblocktrans %}
+                    {% else %}
+                    {% blocktrans %}We received a request to change the e-mail associated with your {{ site_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please click below to confirm your new e-mail address.{% endblocktrans %}
+                    {% endif %}
+                    <br />
+                </p>
+
+                {% trans "Confirm Email Change" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
+
+            </div>
+        </td>
+    </tr>
+    <tr style="background-color: #FFF;">
         <td>
-            <h1>
-                {% trans "Email Change" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
-                {% endfilter %}
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
+                {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ site_name }} web site.{% endblocktrans %}
                 <br />
             </p>
-
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Confirm Email Change{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}If you didn't request this, you don't need to do anything; you won't receive any more email from us. Please do not reply to this e-mail; if you require assistance, check the help section of the {{ platform_name }} web site.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -3,60 +3,65 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
-        <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}Welcome to {{ course_name }}{% endblocktrans %}
-                {% endautoescape %}
-            </h1>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}To get started, please visit https://{{ site_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}The login information for your account follows:{% endblocktrans %}
-                {% endfilter %}
-                <br />
-                {% filter force_escape %}
-                {% blocktrans %}email: {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-                {% filter force_escape %}
-                {% blocktrans %}password: {{ password }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}It is recommended that you change your password.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700; font-size: 1.7em; margin-top: 30px; margin-bottom: 20px;">
+                    {% blocktrans %}
+                    Welcome to {{ course_name }}
+                    {% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}To get started, please visit https://{{ site_name }}.{% endblocktrans %}
+                    <br />
+                </p>
 
-            <p style="color: rgba(0,0,0,.75);">
-              <a href="{{ course_url }}">
-                {% filter force_escape %}
-                {% blocktrans %}You may access your course.{% endblocktrans %}
-                {% endfilter %}
-              </a>
-                <br />
-            </p>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}The login information for your account follows:{% endblocktrans %}
+                    <br />
+                    {% blocktrans %}email: {{ email_address }}{% endblocktrans %}
+                    <br />
+                    {% blocktrans %}password: {{ password }}{% endblocktrans %}
+                    <br />
+                </p>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Sincerely yours, The {{ course_name }} Team{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+                    {% blocktrans %}It is recommended that you change your password.{% endblocktrans %}
+                    <br />
+                </p>
+            </div>
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -3,65 +3,62 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
-        <td>
-            <h1>
-                {% autoescape off %}
-                 {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
+
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
                 {% blocktrans %}
                     You have been invited to be a beta tester for {{ course_name }} at {{ site_name }}
                 {% endblocktrans %}
-                {% endautoescape %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}The invitation has been sent by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            {% if auto_enroll %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To start accessing course materials, please visit:{% endblocktrans %}
-                    {% endfilter %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}The invitation has been sent by a member of the course staff. To start accessing course materials, please click the button below.{% endblocktrans %}
                     <br />
                 </p>
 
+                {% trans "View Course" as course_cta_text %}
+
+                {% if auto_enroll %}
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=display_name|default:course.display_name_with_default course_cta_url=course_url %}
-            {% elif course_about_url is not None %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To enroll in this course and begin the beta test:{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-                {% filter force_escape %}
+                {% elif course_about_url is not None %}
                 {% blocktrans asvar course_cta_text %}Visit {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
-
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_about_url %}
-            {% else %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To enroll in this course and begin the beta test:{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-                {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Visit {{ site_name }}
-                {% endblocktrans %}
-                {%endfilter%}
-
+                {% else %}
+                {% blocktrans asvar course_cta_text %}Visit {{ site_name }}{% endblocktrans %}
                 {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
-            {% endif %}
+                {% endif %}
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
+            </div>
+        </td>
+    </tr>
+    <tr style="background-color: #FFF;">
+        <td>
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
+                {% blocktrans %}This email message was automatically sent because someone attempted to create an account on {{ site_name }} using this email address.{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -5,79 +5,110 @@
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been invited to {{ course_name }}{% endblocktrans %}
-                {% endautoescape %}
-            </h1>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endautoescape %}
-                <br />
-            </p>
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
 
-        {% if is_shib_course %}
-            {% if auto_enroll %}
-                <p style="color: rgba(0,0,0,.75);">
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
                     {% filter force_escape %}
-                    {% blocktrans %}To access this course click on the button below and login:{% endblocktrans %}
+                    {% blocktrans %}You have been invited to {{ course_name }}{% endblocktrans %}
+                    {% endfilter %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% filter force_escape %}
+                    {% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
                     {% endfilter %}
                     <br />
                 </p>
 
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_url %}
-            {% elif course_about_url is not None %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
-                    {% blocktrans %}To access this course visit it and register:{% endblocktrans %}
-                    {% endfilter %}
-                    <br />
-                </p>
-
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
-            {% endif %}
-        {% else %}
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Please finish your registration and fill out the registration form making sure to use {{ email_address }} in the Email field:{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-            {# xss-lint: disable=django-trans-missing-escape #}
-            {% trans "Finish Your Registration" as button_cta_text %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=button_cta_text course_cta_url=registration_url %}
-
-            <p style="color: rgba(0,0,0,.75);">
+                {% if is_shib_course %}
                 {% if auto_enroll %}
-                    {% autoescape off %}
-                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                    {% blocktrans %}Once you have registered and activated your account, you will see {{ course_name }} listed on your dashboard.{% endblocktrans %}
-                    {% endautoescape %}
+                    <p style="padding: 0px;
+                            width: 50%;
+                            min-width: 300px;
+                            margin-top: 20px;
+                            ">
+                        {% filter force_escape %}
+                        {% blocktrans %}To access this course click on the button below and log in.{% endblocktrans %}
+                        {% endfilter %}
+                        <br />
+                    </p>
+
+                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_url %}
                 {% elif course_about_url is not None %}
+                    <p style="padding: 0px;
+                            width: 50%;
+                            min-width: 300px;
+                            margin-top: 20px;
+                            ">
+                        {% filter force_escape %}
+                        {% blocktrans %}To access this course visit it and register:{% endblocktrans %}
+                        {% endfilter %}
+                        <br />
+                    </p>
+
+                    {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
+                {% endif %}
+                {% else %}
+                <p style="padding: 0px;
+                            width: 50%;
+                            min-width: 300px;
+                            margin-top: 20px;
+                            ">
+                    {% filter force_escape %}
+                    {% blocktrans %}Please finish your registration and fill out the registration form, making sure to use {{ email_address }} in the Email field:{% endblocktrans %}
+                    {% endfilter %}
+                    <br />
+                </p>
+                {# xss-lint: disable=django-trans-missing-escape #}
+                {% trans "Finish Your Registration" as button_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=button_cta_text course_cta_url=registration_url %}
+
+                <p style="padding: 0px;
+                            width: 50%;
+                            min-width: 300px;
+                            margin-top: 20px;
+                            ">
+                    {% if auto_enroll %}
+                    {% filter force_escape %}
+                    {% blocktrans %}Once you have registered and activated your account, you will see {{ course_name }} listed on your dashboard.{% endblocktrans %}
+                    {% endfilter %}
+                    {% elif course_about_url is not None %}
                     {% filter force_escape %}
                     {% blocktrans %}Once you have registered and activated your account, you will be able to access this course:{% endblocktrans %}
                     {% endfilter %}
                     {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
-                {% else %}
-                    {% autoescape off %}
-                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                    {% else %}
+                    {% filter force_escape %}
                     {% blocktrans %}You can then enroll in {{ course_name }}.{% endblocktrans %}
-                    {% endautoescape %}
+                    {% endfilter %}
+                    {% endif %}
+                    <br />
+                </p>
                 {% endif %}
-                <br />
-            </p>
-        {% endif %}
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+
+            </div>
         </td>
     </tr>
 </table>

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -3,37 +3,47 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
-    <tr>
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
+   <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
+
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                     {% blocktrans %}You have been unenrolled{% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard. Your other courses have not been affected. {% endblocktrans %}
+                    <br />
+                </p>
+            </div>
+        </td>
+    </tr>
+    <tr style="background-color: #FFF;">
         <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}
-                    You have been unenrolled from {{ course_name }}
-                {% endblocktrans %}
-                {% endautoescape %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endautoescape %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Your other courses have not been affected.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
-                {% endfilter %}
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
+                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -3,35 +3,50 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
-    <tr>
-        <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
+   <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
                     You have been enrolled in {{ course_name }}
-                {% endblocktrans %}
-                {% endautoescape %}
-            </h1>
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
+                    <br />
+                </p>
 
-            <p style="color: rgba(0,0,0,.75);">
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endautoescape %}
-                <br />
-            </p>
+                {% trans "Access the Course Materials Now" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
 
-            {% filter force_escape %}
-                {% blocktrans asvar course_cta_text %}Access the Course Materials Now{% endblocktrans %}
-            {% endfilter %}
-            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=course_url %}
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+            </div>
+        </td>
+    </tr>
+    <tr style="background-color: #FFF;">
+        <td>
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ full_name }}{% endblocktrans %}
-                {% endfilter %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -3,42 +3,48 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
+
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700;">
+                     {% blocktrans %}You have been removed as a beta tester{% endblocktrans %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff. This course will remain on your dashboard, but you will no longer be part of the beta testing group. Your other courses have not been affected. {% endblocktrans %}
+                    <br />
+                </p>
+
+            </div>
+        </td>
+    </tr>
+    <tr style="background-color: #FFF;">
         <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}{% endblocktrans %}
-                {% endautoescape %}
-            </h1>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endautoescape %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This course will remain on your dashboard, but you will no longer be part of the beta testing group.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}Your other courses have not been affected.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+            <p style="margin: 0 40px 40px 40px; text-align: center; color: #444; font-size: 0.9em;">
                 {% blocktrans %}This email was automatically sent from {{ site_name }} to {{ email_address }}{% endblocktrans %}
-                {% endfilter %}
                 <br />
             </p>
         </td>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <!-- These tags come from the ace_common djangoapp in edx ace -->
 {% load ace %}
+{% load static %}
 <!-- These tags come from the edx_ace app within the edx_ace repository -->
 {% load acetags %}
 
@@ -9,7 +10,18 @@
 
 {# This is preview text that is visible in the inbox view of many email clients but not visible in the actual #}
 {# email itself. #}
+<style>
+  body {
+    background-color: #f5f5f5 !important;
+  }
 
+  p, td {
+    font-family: 'Roboto', sans-serif;
+  }
+</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800;900&family=Roboto:wght@100;300;400;500;700;900&display=swap" rel="stylesheet">
 <div lang="{{ LANGUAGE_CODE|default:"en" }}" style="
   display:none;
   font-size:1px;
@@ -30,9 +42,7 @@
 {% google_analytics_tracking_pixel %}
 
 <div bgcolor="#f5f5f5" lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
-  margin: 0;
-  padding: 0;
-  min-width: 100%;
+  padding: 0 20px;
   background-color: #f5f5f5;
   ">
   <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
@@ -48,81 +58,39 @@
   <td>
   <![endif]-->
 
-  <!-- CONTENT -->
-  <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" bgcolor="#fbfaf9" width="100%"
-    {% block table_style %}
-      style="
-      font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      font-size: 1em;
-      line-height: 1.5;
-      max-width: 600px;
-      padding: 0 20px 0 20px;
-      "
-    {% endblock %}
-  >
-    {% block header %}
-      <td class="header" style="background-color: #f5f5f5;">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" bgcolor="#F5F5F5">
-          <tr>
-            <td valign="top" align="center">
-              <table width="600" cellpadding="0" cellspacing="0" align="center" class="width_100percent">
-                <tr>
-                  <td valign="top" align="center" style="min-width:600px;" class="min_width">
-                    <table width="100%" cellpadding="0" cellspacing="0" bgcolor="#F5F5F5">
-                      <tr><td height="10" style="line-height:1px;">&nbsp;</td></tr>
-                      <tr>
-                        <td align="left" valign="top" style="padding:0 60px;" class="padding_none">
-                          <table cellpadding="0" cellspacing="0" align="left" class="width_100percent">
-                            <tr>
-                              <td align="center" valign="top">
-                                <table cellpadding="0" cellspacing="0">
-                                  <tr>
-                                    <td align="left" valign="top">
-                                      <a href="{% with_link_tracking homepage_url %}">
-                                        <img src="{{ logo_url }}" style="max-height: 65px;" height="auto" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
-                                    </td>
-                                  </tr>
-                                </table>
-                              </td>
-                            </tr>
-                          </table>
-                          <table height="66" cellpadding="0" cellspacing="0" align="right" class="width_100percent height_0">
-                            <tr>
-                              <td align="center" valign="middle" class="paddingtop_10">
-                                <table cellpadding="0" cellspacing="0">
-                                  <tr>
-                                    <td align="left" valign="top" style="color: #d23228;">
-                                      {% if courses_url %}
-                                        <a href="{% with_link_tracking courses_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
-                                          {% trans "Courses" as tmsg %}{{ tmsg | force_escape }}
-                                        </a>
-                                        &nbsp; / &nbsp;
-                                      {% endif %}
-                                      {% if programs_url %}
-                                        <a href="{% with_link_tracking programs_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
-                                          {% trans "Programs" as tmsg %}{{ tmsg | force_escape }}
-                                        </a>
-                                        &nbsp; / &nbsp;
-                                      {% endif %}
-                                      <a href="{% with_link_tracking dashboard_url %}" target="_blank" style="font-family:'Inter',Helvetica,Arial,sans-serif;font-size:15px;line-height:20px;text-decoration:none;color:#000001;font-weight:bold;">
-                                        {% trans "My Account" as tmsg %}{{ tmsg | force_escape }}
-                                      </a>
-                                    </td>
-                                  </tr>
-                                </table>
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
-                      </tr>
-                      <tr><td height="10" style="line-height:1px;font-size:1px;">&nbsp;</td></tr>
-                    </table>
-                  </td>
-                </tr>
-              </table>
+    <!-- CONTENT -->
+    <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f5f5" width="100%" style="
+        font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 1em;
+        line-height: 1.5;
+        max-width: 600px;
+        padding: 0 20px 0 20px;
+    ">
+        <tr>
+            <!-- HEADER -->
+            <td class="header" style="
+                padding: 20px;
+            ">
+                {% block header %}
+                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td width="70">
+                      <a href="{% with_link_tracking homepage_url %}"><img
+                        src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" width="40"
+                        height="40" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                    </td>
+                    <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
+                      <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>
+                    </td>
+                  </tr>
+                  <tr><td height="10" style="line-height:1px;font-size:1px;">&nbsp;</td></tr>
+                </table>
             </td>
-          </tr>
-        </table>
+        </tr>
+    </table>
+    </td>
+    </tr>
+    </table>
     {% endblock %}
   </td>
 </tr>
@@ -142,76 +110,8 @@
 
 <tr>
   <!-- FOOTER -->
-  <td class="footer" style="padding: 20px; background-color: #f5f5f5;">
-    <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
-      <tr>
-        <td style="padding-bottom: 20px;">
-          <!-- SOCIAL -->
-          <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
-            <tr>
-              {% if social_media_urls.linkedin %}
-                <td height="32" width="42">
-                  <a href="{{ social_media_urls.linkedin|safe }}">
-                    <img src="{{ social_media_logo_urls.linkedin }}"
-                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}{% endfilter %}"/>
-                  </a>
-                </td>
-              {% endif %}
-              {% if social_media_urls.twitter %}
-                <td height="32" width="42">
-                  <a href="{{ social_media_urls.twitter|safe }}">
-                    <img src= "{{ social_media_logo_urls.twitter }}"
-                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}{% endfilter %}"/>
-                  </a>
-                </td>
-              {% endif %}
-              {% if social_media_urls.facebook %}
-                <td height="32" width="42">
-                  <a href="{{ social_media_urls.facebook|safe }}">
-                    <img src="{{ social_media_logo_urls.facebook }}"
-                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}{% endfilter %}"/>
-                  </a>
-                </td>
-              {% endif %}
-              {% if social_media_urls.google_plus %}
-                <td height="32" width="42">
-                  <a href="{{ social_media_urls.google_plus|safe }}">
-                    <img src="{{ social_media_logo_urls.google_plus}}"
-                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}{% endfilter %}"/>
-                  </a>
-                </td>
-              {% endif %}
-              {% if social_media_urls.reddit %}
-                <td height="32" width="42">
-                  <a href="{{ social_media_urls.reddit|safe }}">
-                    <img src="{{ social_media_logo_urls.reddit}}"
-                      width="32" height="32" alt="{% filter force_escape %}{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}{% endfilter %}"/>
-                  </a>
-                </td>
-              {% endif %}
-            </tr>
-          </table>
-        </td>
-      </tr>
-      <tr>
-        <!-- APP BUTTONS -->
-        <td style="padding-bottom: 20px;">
-          {% if mobile_store_urls.apple %}
-            <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
-              <img src="{{ mobile_store_logo_urls.apple}}"
-                alt="{% trans "Download the iOS app on the Apple Store" as tmsg %}{{ tmsg | force_escape }}"
-                width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
-            </a>
-          {% endif %}
-          {% if mobile_store_urls.google %}
-            <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
-              <img src="{{ mobile_store_logo_urls.google}}"
-                alt="{% trans "Download the Android app on the Google Play Store" as tmsg %}{{ tmsg | force_escape }}"
-                width="136" height="50"/>
-            </a>
-          {% endif %}
-        </td>
-      </tr>
+  <td class="footer" style="padding: 20px; background-color: #f5f5f5; margin-top: 60px;">
+    <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0" style="margin-top: 60px;">
       <tr>
         <!-- Actions -->
         <td style="padding-bottom: 20px; background-color: #f5f5f5;">

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -16,19 +16,21 @@
         {% endif %}
     {% endif %}
     style="
-        color: #ffffff;
+        padding: 15px 20px;
+        margin: 50px 0px;
+        font-family: 'Open Sans', sans-serif;
+        background-color: #FFB81C;
+        font-size: 18px;
+        border: 2px solid #505759;
+        border-radius: 5px;
+        -webkit-border-radius: 5px;
+        -moz-border-radius: 5px;
         text-decoration: none;
-        border-radius: 4px;
-        -webkit-border-radius: 4px;
-        -moz-border-radius: 4px;
-        background-color: #005686;
-        border-top: 12px solid #005686;
-        border-bottom: 12px solid #005686;
-        border-right: 50px solid #005686;
-        border-left: 50px solid #005686;
         display: inline-block;
+        color: #000000;
+
     ">
-        {# old email clients require the use of the font tag :( #}
-        <font color="#ffffff"><b>{{ course_cta_text }}</b></font>
+    {# old email clients require the use of the font tag :( #}
+        <font color="#000000;"><b>{{ course_cta_text }}</b></font>
     </a>
 </p>

--- a/openedx/core/djangoapps/user_authn/tasks.py
+++ b/openedx/core/djangoapps/user_authn/tasks.py
@@ -6,6 +6,7 @@ import logging
 
 from celery import shared_task
 from celery.exceptions import MaxRetriesExceededError
+from crum import get_current_request
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.contrib.sites.models import Site
@@ -68,8 +69,13 @@ def send_activation_email(self, msg_string, from_address=None, site_id=None):
 
     dest_addr = msg.recipient.email_address
 
-    site = Site.objects.get(id=site_id) if site_id else Site.objects.get_current()
-    user = User.objects.get(id=msg.recipient.lms_user_id)
+    # This approach only works with the Pearson-Core's asynchronous site context feature.
+    try:
+        site = get_current_request().site or Site.objects.get_current()
+    except AttributeError:
+        site = Site.objects.get_current()
+
+    user = User.objects.get(username=msg.recipient.username)
 
     try:
         with emulate_http_request(site=site, user=user):

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -1,44 +1,75 @@
 {% extends 'ace_common/edx_ace/common/base_body.html' %}
-
 {% load i18n %}
 {% load static %}
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" style="box-shadow: 0px 0px 10px 2px #c8c8c8;">
     <tr>
-        <td>
-            <h1>
-                {% trans "Password reset" as tmsg %}{{ tmsg | force_escape }}
-            </h1>
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td style="width: 100%;
+            max-width: 800px;
+            background-color: #FFF;
+            color: #000000;
+            margin: auto;
+            text-align: center;
+            padding: 20px;
+            ">
 
-            {% if failed %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% filter force_escape %}
+            <img src="https://partner-courses.pearson.com/static/pearson-theme/images/logo.png" style="width: 150px; padding: 5px; margin: auto;" />
+
+            <div style="width: 90%;
+                        text-align: left;
+                        padding: 2% 5%;
+                        background-color: #D4EAE4;
+                        background-size: 50%;
+                        background-position: right bottom;
+                        background-repeat: no-repeat;
+                        padding-bottom: 35%;
+                        ">
+
+                <h1 style="font-family:'Playfair Display', serif; font-weight: 700; font-size: 1.7em; margin-top: 30px; margin-bottom: 20px;">
+                    {% trans "Password Reset" %}
+                </h1>
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+                </p>
+
+
+                {% if failed %}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
                     {% blocktrans %}However, there is currently no user account associated with your email address: {{ email_address }}.{% endblocktrans %}
-                    {% endfilter %}
                     <br />
                 </p>
 
-                <p style="color: rgba(0,0,0,.75);">
-                    {% trans "If you did not request this change, you can ignore this email." as tmsg %}{{ tmsg | force_escape }}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% trans "If you did not request this change, you can ignore this email." %}
                     <br />
                 </p>
-            {% else %}
-                <p style="color: rgba(0,0,0,.75);">
-                    {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." as tmsg %}{{ tmsg | force_escape }}
+                {% else %}
+                <p style="padding: 0px;
+                          width: 50%;
+                          min-width: 300px;
+                          margin-top: 20px;
+                          ">
+                    {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
                     <br />
                 </p>
-                {# xss-lint: disable=django-trans-missing-escape #}
-                {% trans "Reset my password" as course_cta_text %}
 
-                {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text reset_url=reset_link %}
-            {% endif %}
+                {% trans "Change my Password" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+                {% endif %}
+
+            </div>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
## Description

This PR replaces the default email templates with a Pearson branded ones and adds the Pearson privacy policy extension point to the registration page.

## Changes made

* Cherry pick from https://github.com/Pearson-Advance/edx-platform/pull/100
* Cherry pick from https://github.com/Pearson-Advance/edx-platform/pull/106

## How to test

The email templates

- Test sending the corresponding emails and verify the styles are applied correctly

## Jira issue

https://pearson.atlassian.net/browse/PADV-2736