### PR TITLE
fix: add multiple_ccx_per_coach validation to the ccx view

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -53,6 +53,7 @@ from lms.djangoapps.ccx.utils import (
     get_ccx_for_coach,
     get_date,
     get_enrollment_action_and_identifiers,
+    multiple_ccx_per_coach,
     parse_date
 )
 from lms.djangoapps.courseware.field_overrides import disable_overrides
@@ -153,7 +154,7 @@ def dashboard(request, course, ccx=None):
     """
     # right now, we can only have one ccx per user and course
     # so, if no ccx is passed in, we can sefely redirect to that
-    if ccx is None:
+    if ccx is None and not multiple_ccx_per_coach(course):
         ccx = get_ccx_for_coach(course, request.user)
         if ccx:
             url = reverse(


### PR DESCRIPTION
## Description

This PR fix the missing validation to enable the multiple ccx per coach feature. The function is already defined in pearson/ulmo branch, but the feature is no working because the validation is not integrated.

## How to test

1. Add the setting in the site configuration to enable multiple ccx per coach

```JSON
"ALLOW_MULTIPLE_CCX_PER_COACH": true,
```

2. Enable the ccx tab for a coach
3. In the ccx tab verify you can create multiples ccx