### PR TITLE
feat: add public filters for student logout and registration ToS cust…

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -16,6 +16,7 @@ from openedx.core.djangoapps.safe_sessions.middleware import mark_user_change_as
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from common.djangoapps.third_party_auth import pipeline as tpa_pipeline
+from openedx_filters.authentication.filters import StudentLogoutRequested
 
 
 class LogoutView(TemplateView):
@@ -87,6 +88,9 @@ class LogoutView(TemplateView):
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
+
+        # Trigger the logout filter pipeline (best-effort; logout must still complete).
+        StudentLogoutRequested.run_filter(request=request)
 
         mark_user_change_as_expected(None)
 

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -34,6 +34,7 @@ from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1 as i
 from openedx.core.djangoapps.user_authn.views.utils import remove_disabled_country_from_list
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.enterprise_support.api import enterprise_customer_for_request
+from openedx_filters.authentication.filters import StudentRegistrationFormTermsOfServiceLabelRequested
 
 
 class TrueCheckbox(widgets.CheckboxInput):
@@ -1092,6 +1093,11 @@ class RegistrationFormFactory:
             ),
             tos_link_end=HTML("</a>"),
         )
+        label_with_terms_of_service_and_privacy_policy = StudentRegistrationFormTermsOfServiceLabelRequested.run_filter(
+            label=label,
+            platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
+        )
+        label = label_with_terms_of_service_and_privacy_policy or label
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3015

## Description

This PR integrates two **Open edX public filters** into `edx-platform` by **wiring the filter invocations at the correct LMS execution points** for (1) student logout and (2) registration Terms of Service (ToS) label construction. The goal is to expose stable extension points for Pearson plugins (and other downstreams) while ensuring the core user flows remain unaffected.

## Changes made

### 1. Trigger logout filter during LMS logout
- **Location:** `openedx/core/djangoapps/user_authn/views/logout.py`
- **Hook point:** `LogoutView.dispatch`
- **Filter invoked:** `StudentLogoutRequested`
- **Filter type:** `org.openedx.learning.student.logout.requested.v1`
- **Behavior:**
  - Runs the logout filter pipeline on a best-effort basis immediately after cookies are cleared.
  - Logout completion remains the priority; the filter is invoked as a side-effect extension point.

### 2. Allow ToS label customization during registration form rendering
- **Location:** `openedx/core/djangoapps/user_authn/views/registration_form.py`
- **Hook point:** `_add_terms_of_service_field`
- **Filter invoked:** `StudentRegistrationFormTermsOfServiceLabelRequested`
- **Filter type:** `org.openedx.learning.student.registration.form.terms_of_service.label.requested.v1`
- **Inputs passed:**
  - `label`: the default ToS label constructed by the LMS
  - `platform_name`: resolved from site configuration (`PLATFORM_NAME`) with a settings fallback
- **Behavior:**
  - The filter may return an overridden label; if it returns a falsy value, the original label is preserved:
    - `label = label_with_terms_of_service_and_privacy_policy or label`

## Backward Compatibility / Safety

- Changes are additive and localized to two call sites.
- Default behavior is preserved unless a downstream pipeline provides an override.
- Logout remains best-effort; extensions should not block or break core logout execution.

## PRs Related

- https://github.com/Pearson-Advance/pearson-core/pull/68
- https://github.com/Pearson-Advance/tutor-pearson-plugin/pull/1224
- https://github.com/Pearson-Advance/openedx-filters/pull/8

## Reviewers

- [ ] @JuanDavidBuitrago