### PR TITLE
PADV-2744 - cherry pick adding CCX support to edx notes

### DIFF
--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from xblock.exceptions import NoSuchServiceError
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from common.djangoapps.student.auth import is_ccx_course
 
 
 def edxnotes(cls):
@@ -58,7 +59,8 @@ def edxnotes(cls):
                 "params": {
                     # Use camelCase to name keys.
                     "usageId": self.scope_ids.usage_id,
-                    "courseId": course.id,
+                    # We need to change the value when the course is a CCX because of the issue commented above.
+                    "courseId": course.id if not is_ccx_course(course.id) else course.id.for_branch(branch=None),
                     "token": get_edxnotes_id_token(user),
                     "tokenUrl": get_token_url(course.id),
                     "endpoint": get_public_endpoint(),


### PR DESCRIPTION
## Ticket

https://pearson.atlassian.net/browse/PADV-2744

## Description

This PR add cherry-pick commit from pearson-release/olive.main:

https://github.com/Pearson-Advance/edx-platform/pull/117/changes/ffd3b4a9f2f9a91e8114828c261f82262405b2ea The notes for a CCX are failing to show in the Notes tab