### PR TITLE
PADV-3091: Enable CCX Certificates (Ulmo)

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -476,6 +476,32 @@ def get_certificate_template(course_key, mode, language):
         org_mode_and_key_templates = active_templates.filter(organization_id=org_id, mode=mode, course_key=course_key)
         template = _get_language_specific_template_or_default(language, org_mode_and_key_templates)
 
+    # CCX courses: if no template matched the CCX key, try with the master course key.
+    # CCX courses inherit their certificate template from the master course.
+    # CCX keys are never in OrganizationCourse, so org_id is None for them and the lookup
+    # above is always skipped. We use the master course org to find CCX-specific templates first,
+    # then fall back to the master course template.
+    if not template and hasattr(course_key, 'ccx'):
+        master_course_key = course_key.to_course_locator()
+        master_org_id = get_course_organization_id(master_course_key)
+        if master_org_id and mode:
+            ccx_specific_templates = active_templates.filter(
+                organization_id=master_org_id,
+                mode=mode,
+                course_key=course_key
+            )
+            template = _get_language_specific_template_or_default(language, ccx_specific_templates)
+        if not template and master_org_id and mode:
+            master_templates = active_templates.filter(
+                organization_id=master_org_id,
+                mode=mode,
+                course_key=master_course_key
+            )
+            template = _get_language_specific_template_or_default(language, master_templates)
+        # Also try master org for org+mode fallback (without course_key)
+        if not template and master_org_id:
+            org_id = master_org_id
+
     # since no template matched that course_key, only consider templates with empty course_key
     empty_course_key_templates = active_templates.filter(course_key=CourseKeyField.Empty)
     if not template and org_id and mode:  # get template by org and mode

--- a/lms/djangoapps/certificates/generation_handler.py
+++ b/lms/djangoapps/certificates/generation_handler.py
@@ -168,8 +168,7 @@ def _can_generate_regular_certificate(user, course_key, enrollment_mode, course_
     Check if a regular (non-allowlist) course certificate can be generated (created if it doesn't already exist, or
     updated if it does exist) for this user, in this course run.
     """
-    if _is_ccx_course(course_key):
-        log.info(f'{course_key} is a CCX course. Certificate cannot be generated for {user.id}.')
+    if _is_ccx_cert_generation_blocked(user, course_key):
         return False
 
     if is_beta_tester(user, course_key):
@@ -316,7 +315,7 @@ def _can_set_regular_cert_status(user, course_key, enrollment_mode):
     """
     Determine whether we can set a custom (non-downloadable) cert status for a regular (non-allowlist) certificate
     """
-    if _is_ccx_course(course_key):
+    if _is_ccx_cert_generation_blocked(user, course_key):
         return False
 
     if is_beta_tester(user, course_key):
@@ -380,6 +379,23 @@ def _is_ccx_course(course_key):
     Check if the course is a CCX (custom edX course)
     """
     return hasattr(course_key, 'ccx')
+
+
+def _is_ccx_cert_generation_blocked(user, course_key):
+    """
+    Check if certificate generation is blocked for a CCX course.
+
+    Returns True if the course is a CCX and the ENABLE_CCX_CERTIFICATES feature flag is not enabled.
+    """
+    if _is_ccx_course(course_key) and not getattr(settings, 'ENABLE_CCX_CERTIFICATES', False):
+        log.info(
+            '%s is a CCX course and ENABLE_CCX_CERTIFICATES is not enabled. '
+            'Certificate cannot be generated for %s.',
+            course_key,
+            user.id,
+        )
+        return True
+    return False
 
 
 def _has_passing_grade_or_is_allowlisted(user, course_key, course_grade):

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import ddt
 import pytz
+from ccx_keys.locator import CCXLocator
 from config_models.models import cache
 from django.conf import settings
 from django.test import RequestFactory, TestCase
@@ -16,8 +17,10 @@ from django.urls import reverse
 from django.utils import timezone
 from edx_toggles.toggles.testutils import override_waffle_switch
 from freezegun import freeze_time
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
+from organizations.models import Organization
 from testfixtures import LogCapture
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -44,6 +47,7 @@ from lms.djangoapps.certificates.api import (
     get_certificate_for_user_id,
     get_certificate_header_context,
     get_certificate_invalidation_entry,
+    get_certificate_template,
     get_certificate_url,
     get_certificates_for_user,
     get_course_ids_from_certs_for_user,
@@ -54,10 +58,12 @@ from lms.djangoapps.certificates.api import (
     remove_allowlist_entry,
     set_cert_generation_enabled,
 )
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.certificates.config import AUTO_CERTIFICATE_GENERATION
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateStatuses,
+    CertificateTemplate,
     GeneratedCertificate,
 )
 from lms.djangoapps.certificates.tests.factories import (
@@ -1319,3 +1325,67 @@ class GetCourseIdsForUsernameTests(TestCase):
         """
         course_ids = get_course_ids_from_certs_for_user("nonexistentuser")
         self.assertEqual(course_ids, [])
+
+
+class CCXCertificateTemplateTests(ModuleStoreTestCase):
+    """Tests for CCX certificate template fallback to master course."""
+
+    def setUp(self):
+        super().setUp()
+        self.coach = UserFactory()
+        self.course_run = CourseFactory.create()
+        self.ccx = CcxFactory(course_id=self.course_run.id, coach=self.coach)
+        self.ccx_key = CCXLocator.from_course_locator(self.course_run.id, str(self.ccx.id))
+        self.master_key = self.course_run.id
+        self.org = self.course_run.org
+        self.org_obj, _ = Organization.objects.get_or_create(short_name=self.org)
+        mock_org_id = patch(
+            'lms.djangoapps.certificates.api.get_course_organization_id',
+            side_effect=lambda key: None if hasattr(key, 'ccx') else self.org_obj.id
+        )
+        mock_org_id.start()
+        self.addCleanup(mock_org_id.stop)
+
+    def _create_template(self, course_key=CourseKeyField.Empty, org_id=None, mode='honor', language=None):
+        template = CertificateTemplate(
+            name=f'template-{course_key}-{mode}',
+            template='<html>test</html>',
+            organization_id=org_id,
+            course_key=course_key,
+            mode=mode,
+            is_active=True,
+            language=language,
+        )
+        template.save()
+        return template
+
+    def test_ccx_inherits_master_course_template(self):
+        """CCX without own template inherits template by master course_key."""
+        template = self._create_template(course_key=self.master_key, org_id=self.org_obj.id)
+        result = get_certificate_template(self.ccx_key, 'honor', None)
+        assert result == template
+
+    def test_ccx_inherits_master_org_mode_template(self):
+        """CCX inherits org+mode template from master when no course_key match."""
+        template = self._create_template(course_key=CourseKeyField.Empty, org_id=self.org_obj.id)
+        result = get_certificate_template(self.ccx_key, 'honor', None)
+        assert result == template
+
+    def test_ccx_own_template_takes_priority(self):
+        """CCX own template takes priority over master course template."""
+        ccx_template = self._create_template(course_key=self.ccx_key, org_id=self.org_obj.id)
+        self._create_template(course_key=self.master_key, org_id=self.org_obj.id)
+        result = get_certificate_template(self.ccx_key, 'honor', None)
+        assert result == ccx_template
+
+    def test_regular_course_unaffected(self):
+        """Regular courses are not affected by CCX fallback logic."""
+        template = self._create_template(course_key=self.master_key, org_id=self.org_obj.id)
+        result = get_certificate_template(self.master_key, 'honor', None)
+        assert result == template
+
+    def test_ccx_falls_back_to_mode_only(self):
+        """CCX without master org falls back to mode-only template."""
+        mode_template = self._create_template(course_key=CourseKeyField.Empty, org_id=None, mode='honor')
+        result = get_certificate_template(self.ccx_key, 'honor', None)
+        assert result == mode_template

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -5,6 +5,7 @@ import logging
 from unittest import mock
 
 import ddt
+from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.test import override_settings
 
@@ -15,7 +16,9 @@ from lms.djangoapps.certificates.generation_handler import (
     _can_generate_allowlist_certificate,
     _can_generate_certificate_for_status,
     _can_generate_regular_certificate,
+    _can_set_regular_cert_status,
     _generate_regular_certificate_task,
+    _is_ccx_cert_generation_blocked,
     _set_allowlist_cert_status,
     _set_regular_cert_status,
     generate_allowlist_certificate_task,
@@ -23,6 +26,7 @@ from lms.djangoapps.certificates.generation_handler import (
     is_on_certificate_allowlist
 )
 from lms.djangoapps.certificates.models import GeneratedCertificate
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.certificates.tests.factories import (
     CertificateAllowlistFactory,
     CertificateInvalidationFactory,
@@ -800,3 +804,125 @@ class CertificateTests(ModuleStoreTestCase):
                 mock.patch(PASSING_GRADE_METHOD, return_value=True), \
                 override_settings(FEATURES={**settings.FEATURES, 'DISABLE_HONOR_CERTIFICATES': True}):
             assert not _can_generate_regular_certificate(self.user, course_run_key, enrollment_mode, grade)
+
+
+class CCXCertGenerationBlockedTests(ModuleStoreTestCase):
+    """
+    Tests for _is_ccx_cert_generation_blocked().
+
+    Verifies that the function correctly blocks or allows certificate generation
+    for CCX courses based on the ENABLE_CCX_CERTIFICATES feature flag.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.coach = UserFactory()
+        self.course_run = CourseFactory()
+        self.ccx = CcxFactory(course_id=self.course_run.id, coach=self.coach)
+        self.ccx_key = CCXLocator.from_course_locator(self.course_run.id, str(self.ccx.id))
+        self.regular_key = self.course_run.id
+
+    def test_blocked_for_ccx_by_default(self):
+        """CCX certificate generation is blocked when the flag is not set."""
+        self.assertTrue(_is_ccx_cert_generation_blocked(self.user, self.ccx_key))
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=False)
+    def test_blocked_for_ccx_when_flag_false(self):
+        """CCX certificate generation is blocked when the flag is explicitly False."""
+        self.assertTrue(_is_ccx_cert_generation_blocked(self.user, self.ccx_key))
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_not_blocked_for_ccx_when_flag_true(self):
+        """CCX certificate generation is allowed when the flag is True."""
+        self.assertFalse(_is_ccx_cert_generation_blocked(self.user, self.ccx_key))
+
+    def test_not_blocked_for_regular_course(self):
+        """Regular courses are never blocked by this check."""
+        self.assertFalse(_is_ccx_cert_generation_blocked(self.user, self.regular_key))
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_not_blocked_for_regular_course_with_flag_enabled(self):
+        """Regular courses are not affected even when the CCX flag is enabled."""
+        self.assertFalse(_is_ccx_cert_generation_blocked(self.user, self.regular_key))
+
+
+@mock.patch.dict(settings.FEATURES, ENABLE_CERTIFICATES_IDV_REQUIREMENT=False)
+@mock.patch(ID_VERIFIED_METHOD, mock.Mock(return_value=True))
+@mock.patch(PASSING_GRADE_METHOD, mock.Mock(return_value=True))
+@mock.patch(WEB_CERTS_METHOD, mock.Mock(return_value=True))
+class CCXCertificateFeatureFlagTests(ModuleStoreTestCase):
+    """
+    Tests for the ENABLE_CCX_CERTIFICATES feature flag.
+
+    This class verifies that:
+    - CCX certificates are blocked by default (flag not set or False)
+    - CCX certificates can be generated when the flag is True
+    - Enabling the flag does not bypass other certificate requirements (grade, enrollment, mode)
+    - The flag does not affect non-CCX courses
+
+    Uses a real CCX course (CcxFactory + CCXLocator) so that _is_ccx_course()
+    detects the CCX via hasattr(course_key, 'ccx') without mocking.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.coach = UserFactory()
+        self.course_run = CourseFactory()
+        self.ccx = CcxFactory(course_id=self.course_run.id, coach=self.coach)
+        self.ccx_key = CCXLocator.from_course_locator(self.course_run.id, str(self.ccx.id))
+        self.enrollment_mode = CourseMode.VERIFIED
+        self.grade = CourseGradeFactory().read(self.user, self.course_run)
+        CourseEnrollmentFactory(
+            user=self.user,
+            course_id=self.ccx_key,
+            is_active=True,
+            mode=self.enrollment_mode,
+        )
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=False)
+    def test_blocked_when_flag_explicitly_false(self):
+        """
+        Test that CCX certificates are blocked when ENABLE_CCX_CERTIFICATES is explicitly False.
+        """
+        self.assertFalse(_can_generate_regular_certificate(
+            self.user, self.ccx_key, self.enrollment_mode, self.grade,
+        ))
+        self.assertFalse(_can_set_regular_cert_status(
+            self.user, self.ccx_key, self.enrollment_mode,
+        ))
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_can_generate_when_flag_enabled(self):
+        """
+        Test that CCX certificates can be generated when ENABLE_CCX_CERTIFICATES is True.
+        """
+        self.assertTrue(_can_generate_regular_certificate(
+            self.user, self.ccx_key, self.enrollment_mode, self.grade,
+        ))
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_generate_task_succeeds_when_flag_enabled(self):
+        """
+        Test that the full certificate generation task succeeds for CCX when flag is enabled.
+        """
+        self.assertTrue(_generate_regular_certificate_task(self.user, self.ccx_key))
+
+
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_flag_does_not_affect_non_ccx_courses(self):
+        """
+        Test that the ENABLE_CCX_CERTIFICATES flag does not alter behavior for regular (non-CCX) courses.
+        A regular course key (without .ccx attribute) should still generate certificates normally.
+        """
+        regular_key = self.course_run.id
+        CourseEnrollmentFactory(
+            user=self.user,
+            course_id=regular_key,
+            is_active=True,
+            mode=self.enrollment_mode,
+        )
+        self.assertTrue(_can_generate_regular_certificate(
+            self.user, regular_key, self.enrollment_mode, self.grade,
+        ))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2539,6 +2539,29 @@ RSS_PROXY_CACHE_TIMEOUT = 3600  # The length of time we cache RSS retrieved from
 #   hard limit, chosen so that a CCX does not compete with public MOOCs.
 CCX_MAX_STUDENTS_ALLOWED = 200
 
+# .. toggle_name: settings.ENABLE_CCX_CERTIFICATES
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Set to True to enable certificate generation for CCX (Custom Courses for edX).
+#   By default, certificate generation is blocked for all CCX courses. When enabled, CCX students
+#   who pass the course will receive certificates through the regular certificate generation flow.
+#   The enrollment mode for new CCX enrollments is controlled by the CCX_DEFAULT_ENROLLMENT_MODE
+#   setting, which defaults to 'honor' (certificate-eligible).
+# .. toggle_warning: Requires CUSTOM_COURSES_EDX to also be True.
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2026-02-08
+ENABLE_CCX_CERTIFICATES = False
+
+# .. setting_name: CCX_DEFAULT_ENROLLMENT_MODE
+# .. setting_default: honor
+# .. setting_description: Default enrollment mode for new CCX (Custom Courses for edX) enrollments.
+#   CCX courses have no CourseMode records, so enrollments default to 'audit' which is not
+#   certificate-eligible. This setting overrides that default to a certificate-eligible mode.
+#   Common choices: 'honor', 'no-id-professional', 'professional', 'verified'.
+# .. setting_warning: Only takes effect when ENABLE_CCX_CERTIFICATES is True.
+#   The value must be a certificate-eligible mode (any mode except 'audit').
+CCX_DEFAULT_ENROLLMENT_MODE = 'honor'
+
 # Financial assistance settings
 
 # Maximum and minimum length of answers, in characters, for the

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -469,8 +469,15 @@ def _default_course_mode(course_id):
     Returns:
         str
     """
-    course_modes = CourseMode.modes_for_course(CourseKey.from_string(course_id))
+    course_key = CourseKey.from_string(course_id)
+    course_modes = CourseMode.modes_for_course(course_key)
     available_modes = [m.slug for m in course_modes]
+
+    # CCX courses have no CourseMode records, so they default to 'audit'
+    # which is not certificate-eligible. When ENABLE_CCX_CERTIFICATES is
+    # enabled, use the operator-configured mode instead.
+    if hasattr(course_key, 'ccx') and getattr(settings, 'ENABLE_CCX_CERTIFICATES', False):
+        return getattr(settings, 'CCX_DEFAULT_ENROLLMENT_MODE', 'audit')
 
     if CourseMode.DEFAULT_MODE_SLUG in available_modes:
         return CourseMode.DEFAULT_MODE_SLUG

--- a/openedx/core/djangoapps/enrollments/tests/test_api.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_api.py
@@ -300,3 +300,113 @@ class EnrollmentTest(CacheIsolationTestCase):
             assert result['is_active']
         else:
             assert not result['is_active']
+
+
+class DefaultCourseModeTests(CacheIsolationTestCase):
+    """
+    Tests for _default_course_mode().
+
+    Covers all code paths:
+    1. CCX + ENABLE_CCX_CERTIFICATES flag → returns CCX_DEFAULT_ENROLLMENT_MODE setting
+    2. DEFAULT_MODE_SLUG in available modes → returns DEFAULT_MODE_SLUG
+    3. 'audit' in available modes → returns 'audit'
+    4. 'honor' in available modes → returns 'honor'
+    5. No matching modes → returns DEFAULT_MODE_SLUG as final fallback
+    """
+
+    REGULAR_COURSE_ID = 'course-v1:TestOrg+Course1+Run1'
+    CCX_COURSE_ID = 'ccx-v1:TestOrg+Course1+Run1+ccx@5'
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_ccx_returns_configured_mode_when_flag_enabled(self, mock_modes):
+        """When ENABLE_CCX_CERTIFICATES is True, CCX should use CCX_DEFAULT_ENROLLMENT_MODE."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        with override_settings(CCX_DEFAULT_ENROLLMENT_MODE='honor'):
+            result = api._default_course_mode(self.CCX_COURSE_ID)
+        self.assertEqual(result, 'honor')
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_ccx_uses_custom_mode_from_setting(self, mock_modes):
+        """Operators can configure any certificate-eligible mode via the setting."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        with override_settings(CCX_DEFAULT_ENROLLMENT_MODE='no-id-professional'):
+            result = api._default_course_mode(self.CCX_COURSE_ID)
+        self.assertEqual(result, 'no-id-professional')
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_ccx_with_explicit_modes_still_uses_setting(self, mock_modes):
+        """Even if a CCX has real CourseMode records, the setting takes precedence when the flag is enabled."""
+        mock_modes.return_value = [Mock(slug='audit'), Mock(slug='verified')]
+        with override_settings(CCX_DEFAULT_ENROLLMENT_MODE='no-id-professional'):
+            result = api._default_course_mode(self.CCX_COURSE_ID)
+        self.assertEqual(result, 'no-id-professional')
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_ccx_defaults_to_audit_when_flag_disabled(self, mock_modes):
+        """Without the feature flag, CCX enrollment mode should be audit (default)."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        result = api._default_course_mode(self.CCX_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    @override_settings(ENABLE_CCX_CERTIFICATES=False)
+    def test_ccx_defaults_to_audit_when_flag_explicitly_false(self, mock_modes):
+        """When ENABLE_CCX_CERTIFICATES is explicitly False, CCX stays on audit."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        result = api._default_course_mode(self.CCX_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    @override_settings(ENABLE_CCX_CERTIFICATES=True)
+    def test_regular_course_unaffected_by_flag(self, mock_modes):
+        """Non-CCX courses should not be affected by the CCX feature flag."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        with override_settings(CCX_DEFAULT_ENROLLMENT_MODE='no-id-professional'):
+            result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_default_mode_slug_when_available(self, mock_modes):
+        """When DEFAULT_MODE_SLUG is in available modes, return it."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG), Mock(slug='verified')]
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_default_mode_slug_when_only_mode(self, mock_modes):
+        """When DEFAULT_MODE_SLUG is the only mode, return it."""
+        mock_modes.return_value = [Mock(slug=CourseMode.DEFAULT_MODE_SLUG)]
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_audit_when_available(self, mock_modes):
+        """When 'audit' is available but DEFAULT_MODE_SLUG is not, return 'audit'."""
+        mock_modes.return_value = [Mock(slug='audit'), Mock(slug='verified')]
+        # This path only differs from path 2 if DEFAULT_MODE_SLUG != 'audit'
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertIn(result, [CourseMode.DEFAULT_MODE_SLUG, 'audit'])
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_honor_when_only_honor_available(self, mock_modes):
+        """When only 'honor' is available, return 'honor'."""
+        mock_modes.return_value = [Mock(slug='honor')]
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, 'honor')
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_honor_when_honor_and_verified_available(self, mock_modes):
+        """When 'honor' and 'verified' are available (but not audit/default), return 'honor'."""
+        mock_modes.return_value = [Mock(slug='honor'), Mock(slug='verified')]
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, 'honor')
+
+    @patch('openedx.core.djangoapps.enrollments.api.CourseMode.modes_for_course')
+    def test_returns_default_mode_slug_as_final_fallback(self, mock_modes):
+        """When no known mode is available, return DEFAULT_MODE_SLUG as fallback."""
+        mock_modes.return_value = [Mock(slug='verified'), Mock(slug='professional')]
+        result = api._default_course_mode(self.REGULAR_COURSE_ID)
+        self.assertEqual(result, CourseMode.DEFAULT_MODE_SLUG)


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3091

## Description

In Open edX Ulmo, the FEATURES dictionary was refactored into top-level Django settings variables. A backward-compatible FeaturesProxy was introduced to allow legacy FEATURES['KEY'] access, but it only works when the variables exist as top-level settings in the namespace.

The CCX Certificates feature flags (ENABLE_CCX_CERTIFICATES, CCX_DEFAULT_ENROLLMENT_MODE) were originally added using the old FEATURES dict syntax, which left them as orphaned dict entries outside any dictionary, effectively dead code that was never evaluated.

This PR properly declares both settings as top-level variables in lms/envs/common.py and updates all consumer code and tests to use the Ulmo-style access pattern (getattr(settings, ...) / @override_settings(...)).

## Changes Made

### Settings (lms/envs/common.py)
- Added ENABLE_CCX_CERTIFICATES = False as a top-level setting with proper OEP-17 toggle annotations
- Added CCX_DEFAULT_ENROLLMENT_MODE = 'honor' as a top-level setting with proper annotations
- Both placed in the existing #### Custom Courses for EDX (CCX) configuration section

### Certificate generation (lms/djangoapps/certificates/generation_handler.py)
- Updated _is_ccx_cert_generation_blocked() to use getattr(settings, 'ENABLE_CCX_CERTIFICATES', False) instead of settings.FEATURES.get(...)
- Enrollment API (openedx/core/djangoapps/enrollments/api.py)
- Updated _default_course_mode() to use getattr(settings, 'ENABLE_CCX_CERTIFICATES', False) instead of settings.FEATURES.get(...)

## How to test

- Deploy edx-platform with the feature flag changes                                                                                        
- Create a master course with:                                                                                 
       - Certificate template configured at org level                                                                                            
       - cert_html_view_enabled = True                                                                                                            
       - HTML certificates enabled globally (CERTIFICATES_HTML_VIEW = True)
       - Mark the course as self-paced or set the CCX end date
       - Active the certificate in settings
- Create a new template for the master course (http://localhost:18000/admin/certificates/certificatetemplate/)                                                                       
- Create a CCX from the master course                                                                                                      
- Enroll a student in the CCX 
- Get a passing grade from the CCX
- Check in http://localhost:18000/admin/certificates/generatedcertificate table if a new instance was generated
- Using the verify UUID check the certificate http://localhost:18000/certificates/<verify_uuid>

Copy and parte following lines in the Django Shell:

```
from django.contrib.auth.models import User
from opaque_keys.edx.locator import CCXLocator
from lms.djangoapps.grades.api import CourseGradeFactory
from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED

from unittest.mock import Mock

user = User.objects.get(username='<student_username>')
ccx_key = CCXLocator.from_string('ccx-v1:<org>+<course>+<run>+ccx@<id>')

mock_grade = Mock()
mock_grade.percent = 0.9
mock_grade.passed = True

COURSE_GRADE_NOW_PASSED.send(
    sender=None,
    user=user,
    course_id=ccx_key,
    course_grade=mock_grade,
)
```

After firing, verify the certificate was created:

```
from lms.djangoapps.certificates.models import GeneratedCertificate

cert = GeneratedCertificate.objects.filter(user=user, course_id=ccx_key).first()
if cert:
    print(f"Status: {cert.status}, Grade: {cert.grade}, Mode: {cert.mode}")
else:
    print("No certificate generated")
```

## How to run unit tests

- Open LMS container
- Run `python -m pytest openedx/core/djangoapps/enrollments/tests/test_api.py::DefaultCourseModeTests -v`
- Run `python -m pytest lms/djangoapps/certificates/tests/test_generation_handler.py::CCXCertificateFeatureFlagTests -v`
- Run `python -m pytest lms/djangoapps/certificates/tests/test_generation_handler.py::CCXCertGenerationBlockedTests -v `