### PR TITLE
PADV-3283: CCX Certificates should show master course title

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -51,9 +51,12 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.tests.assertions.events import assert_event_matches
 from openedx.features.name_affirmation_api.utils import get_name_affirmation_service
+from ccx_keys.locator import CCXLocator
 from xmodule.data import CertificatesDisplayBehaviors  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.tests.factories import CourseFactory  # lint-amnesty, pylint: disable=wrong-import-order
+
+from lms.djangoapps.ccx.tests.factories import CcxFactory
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
@@ -1769,3 +1772,76 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
             },
             actual_event
         )
+
+
+@override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+class CCXCertificateDisplayNameTests(CommonCertificatesTestCase):
+    """Tests that CCX certificates display the master course name instead of the CCX class name."""
+
+    ENABLED_SIGNALS = ['course_published']
+
+    def setUp(self):
+        super().setUp()
+        self.ccx = CcxFactory(course_id=self.course.id, coach=self.user, display_name='My CCX Class Name')
+        self.ccx_key = CCXLocator.from_course_locator(self.course.id, str(self.ccx.id))
+
+    def test_ccx_certificate_shows_master_course_name(self):
+        """CCX certificate should display the master course display_name, not the CCX class name."""
+        test_certificates = [
+            {
+                'id': 0,
+                'name': 'Name 0',
+                'description': 'Description 0',
+                'signatories': [],
+                'version': 1,
+                'is_active': True
+            }
+        ]
+        self.course.certificates = {'certificates': test_certificates}
+        self.course.cert_html_view_enabled = True
+        self.course.save()
+        self.update_course(self.course, self.user.id)
+
+        ccx_verify_uuid = uuid4().hex
+        GeneratedCertificateFactory.create(
+            user=self.user,
+            course_id=self.ccx_key,
+            verify_uuid=ccx_verify_uuid,
+            download_uuid=uuid4().hex,
+            download_url="https://www.example.com/certificates/download",
+            grade="0.95",
+            key='the_key',
+            distinction=True,
+            status=CertificateStatuses.downloadable,
+            mode='honor',
+            name=self.user.profile.name,
+        )
+
+        test_url = reverse('certificates:render_cert_by_uuid', kwargs={'certificate_uuid': ccx_verify_uuid})
+        response = self.client.get(test_url)
+        self.assertContains(response, 'refundable course')
+        self.assertNotContains(response, 'My CCX Class Name')
+
+    def test_ccx_certificate_with_course_title_shows_course_title(self):
+        """When certificate has a course_title configured, it should take priority over master course name."""
+        self._add_course_certificates(count=1, signatory_count=0)
+
+        ccx_verify_uuid = uuid4().hex
+        GeneratedCertificateFactory.create(
+            user=self.user,
+            course_id=self.ccx_key,
+            verify_uuid=ccx_verify_uuid,
+            download_uuid=uuid4().hex,
+            download_url="https://www.example.com/certificates/download",
+            grade="0.95",
+            key='the_key',
+            distinction=True,
+            status=CertificateStatuses.downloadable,
+            mode='honor',
+            name=self.user.profile.name,
+        )
+
+        test_url = reverse('certificates:render_cert_by_uuid', kwargs={'certificate_uuid': ccx_verify_uuid})
+        response = self.client.get(test_url)
+        self.assertContains(response, 'course_title_0')
+        self.assertNotContains(response, 'My CCX Class Name')

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -52,6 +52,7 @@ from lms.djangoapps.certificates.utils import (
 )
 from openedx.core.djangoapps.catalog.api import get_course_run_details
 from openedx.core.djangoapps.content.course_overviews.api import get_course_overview_or_none
+from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
@@ -249,7 +250,14 @@ def _update_course_context(request, context, course, platform_name):
     """
     context['full_course_image_url'] = request.build_absolute_uri(course_image_url(course))
     course_title_from_cert = context['certificate_data'].get('course_title', '')
-    accomplishment_copy_course_name = course_title_from_cert if course_title_from_cert else course.display_name
+    if course_title_from_cert:
+        accomplishment_copy_course_name = course_title_from_cert
+    elif hasattr(course.id, 'ccx'):
+        master_course_key = course.id.to_course_locator()
+        master_course = modulestore().get_course(master_course_key)
+        accomplishment_copy_course_name = master_course.display_name
+    else:
+        accomplishment_copy_course_name = course.display_name
     context['accomplishment_copy_course_name'] = accomplishment_copy_course_name
     course_number = course.display_coursenumber if course.display_coursenumber else course.number
     context['course_number'] = course_number


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3283

## Description

When viewing a generated certificate for a CCX (Custom Course for EdX), the certificate displayed the CCX class name instead of the master course name. This occurred because the certificate rendering code uses course.display_name, which for CCX courses returns the overridden CCX name from the CcxFieldOverride table, not the original master course name.

## Changes Made

- **lms/djangoapps/certificates/views/webview.py**: Modified _update_course_context() to detect when the course is a CCX (via hasattr(course.id, 'ccx')) and retrieve the display_name from the master course using to_course_locator() instead of using the CCX overridden name. Added modulestore import to support loading the master course.
- **lms/djangoapps/certificates/tests/test_webview_views.py**: Added CCXCertificateDisplayNameTests test class with two tests: one verifying that CCX certificates display the master course name when no course_title is configured in the certificate template, and another verifying that course_title from the certificate template takes priority when configured.

## How to test

- Follow instructions here: [CCX Certificates End-to-End Testing Guide](https://3.basecamp.com/3966315/buckets/16531373/documents/9753448803)
- Check if the master course title is included in the cert

## How to run unit tests

- Open LMS container
- Run `python -m pytest lms/djangoapps/certificates/tests/test_webview_views.py::CCXCertificateDisplayNameTests -v`