### PR TITLE
feat: add DISCUSSIONS_MICROFRONTEND_URL site aware.

### DIFF
--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -14,6 +14,7 @@ from openedx_events.learning.signals import USER_NOTIFICATION_REQUESTED, COURSE_
 
 from openedx.core.djangoapps.course_groups.models import CourseCohortsSettings
 from openedx.core.djangoapps.discussions.utils import get_divided_discussions
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from django.utils.translation import gettext_lazy as _
 
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
@@ -70,7 +71,12 @@ class DiscussionNotificationSender:
                 **extra_context,
             },
             notification_type=notification_type,
-            content_url=f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/posts/{self.thread.id}",
+            content_url=(
+                f"{configuration_helpers.get_value(
+                    'DISCUSSIONS_MICROFRONTEND_URL',
+                    settings.DISCUSSIONS_MICROFRONTEND_URL,
+                )}/{self.course.id}/posts/{self.thread.id}"
+            ),
             app_name="discussion",
             course_key=self.course.id,
         )
@@ -96,7 +102,12 @@ class DiscussionNotificationSender:
                 **extra_context,
             },
             notification_type=notification_type,
-            content_url=f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/posts/{self.thread.id}",
+            content_url=(
+                f"{configuration_helpers.get_value(
+                    'DISCUSSIONS_MICROFRONTEND_URL',
+                    settings.DISCUSSIONS_MICROFRONTEND_URL,
+                )}/{self.course.id}/posts/{self.thread.id}"
+            ),
             app_name="discussion",
             audience_filters=audience_filters,
         )

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -276,7 +276,10 @@ def redirect_forum_url_to_new_mfe(request, course_id):
 
     redirect_url = None
     if discussions_mfe_enabled:
-        mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+        mfe_base_url = configuration_helpers.get_value(
+            'DISCUSSIONS_MICROFRONTEND_URL',
+            settings.DISCUSSIONS_MICROFRONTEND_URL,
+        )
         redirect_url = f"{mfe_base_url}/{str(course_key)}"
     return redirect_url
 
@@ -336,7 +339,10 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
     if discussions_mfe_enabled:
-        mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+        mfe_base_url = configuration_helpers.get_value(
+            'DISCUSSIONS_MICROFRONTEND_URL',
+            settings.DISCUSSIONS_MICROFRONTEND_URL,
+        )
         if thread_id:
             redirect_url = f"{mfe_base_url}/{str(course_key)}/posts/{thread_id}"
     return redirect_url
@@ -633,7 +639,7 @@ def create_user_profile_context(request, course_key, user_id):
             'num_pages': query_params['num_pages'],
             'sort_preference': user.default_sort_key,
             'learner_profile_page_url': urljoin(
-                 configuration_helpers.get_value(
+                configuration_helpers.get_value(
                     'PROFILE_MICROFRONTEND_URL',
                     settings.PROFILE_MICROFRONTEND_URL,
                 ),
@@ -663,7 +669,10 @@ def user_profile(request, course_key, user_id):
         else:
             discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
             if discussions_mfe_enabled:
-                mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
+                mfe_base_url = configuration_helpers.get_value(
+                    'DISCUSSIONS_MICROFRONTEND_URL',
+                    settings.DISCUSSIONS_MICROFRONTEND_URL,
+                )
                 return redirect(f"{mfe_base_url}/{str(course_key)}/learners")
 
             tab_view = CourseTabView()

--- a/openedx/core/djangoapps/discussions/url_helpers.py
+++ b/openedx/core/djangoapps/discussions/url_helpers.py
@@ -7,6 +7,8 @@ from urllib.parse import urlencode
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 
 def _get_url_with_view_query_params(path: str, view: Optional[str] = None) -> str:
     """
@@ -20,9 +22,17 @@ def _get_url_with_view_query_params(path: str, view: Optional[str] = None) -> st
         (str) URL link for MFE
 
     """
-    if settings.DISCUSSIONS_MICROFRONTEND_URL is None:
+    if configuration_helpers.get_value(
+        'DISCUSSIONS_MICROFRONTEND_URL',
+        settings.DISCUSSIONS_MICROFRONTEND_URL,
+    ) is None:
         return ''
-    url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{path}"
+    url = (
+        f"{configuration_helpers.get_value(
+            'DISCUSSIONS_MICROFRONTEND_URL',
+            settings.DISCUSSIONS_MICROFRONTEND_URL,
+        )}/{path}"
+    )
 
     query_params = {}
     if view == "in_context":


### PR DESCRIPTION
## Description

Adds awareness of Discussions MFE site configuration to ensure correct behavior in the Ulmo environment. This aligns configuration usage across services and prevents inconsistencies during migration.

## Changes made
- [x] add Discussions MFE site configurations handling.

## Testing instructions
- Deploy in staging/Ulmo environment
- Verify Discussions MFE URLs resolve correctly
- Validate discussion navigation (posts, threads)
- Confirm no regressions in logs

## Reviewers

- [x] @JuanDavidBuitrago