### PR TITLE
PADV-3345: Skip auto-enrolling master course staff into licensed CCXs

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -287,7 +287,8 @@ def create_ccx(request, course, ccx=None):
         )
 
         assign_staff_role_to_ccx(ccx_id, request.user, course.id)
-        add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
+        if not is_course_licensing_enabled:
+            add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
         def publish_ccx():
             """Send course_published signal for the CCX after the transaction commits and log receiver responses."""


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3345

## Description

When a CCX is created, add_master_course_staff_to_ccx enrolls every staff and instructor of the master course into the new CCX and sends them an enrollment email. This is the desired behavior for unlicensed CCXs, but for licensed CCXs the staff/instructor membership should be managed exclusively through the institution's licensing flow.

This change wraps the call in if not is_course_licensing_enabled: (reusing the same flag already computed earlier in the view), so licensed CCXs no longer auto-propagate master course staff and no longer trigger the unexpected "you've been enrolled" emails reported by affected users.

## Changes Made

- lms/djangoapps/ccx/views.py

## How to test

- Create a new class (CCX)
- In the table at http://localhost:18000/admin/student/courseaccessrole/, verify that only Institution Admins belonging to that institution were assigned as CCX staff.