### PR TITLE
feat: add COMMUNICATIONS_MICROFRONTEND_URL site aware

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -758,9 +758,14 @@ def _section_send_email(course, access):
         ),
     }
     if settings.FEATURES.get("ENABLE_NEW_BULK_EMAIL_EXPERIENCE", False) is not False:
+        communications_microfrontend_url = configuration_helpers.get_value(
+            "COMMUNICATIONS_MICROFRONTEND_URL",
+            settings.COMMUNICATIONS_MICROFRONTEND_URL,
+        )
+
         section_data[
             "communications_mfe_url"
-        ] = f"{settings.COMMUNICATIONS_MICROFRONTEND_URL}/courses/{str(course_key)}/bulk_email"
+        ] = f"{communications_microfrontend_url}/courses/{str(course_key)}/bulk_email"
     return section_data
 
 


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-3361

### Description
Adds Communications MFE site aware configuration to ensure correct behavior in the Ulmo environment

### Changes made
lms/djangoapps/instructor/views/instructor_dashaboard.py

### Testing instructions
Deploy in staging/Ulmo environment
Enable bulk email and feature ENABLE_NEW_BULK_EMAIL_EXPERIENCE to see the communications MFE 
Go to instructor tab, select email tab and you will see the link to open the MFE

