### PR TITLE
PADV-3271 BE - Gradebook - Change username to fullname

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from functools import wraps
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db.models import Case, Exists, F, OuterRef, Q, When
@@ -57,6 +58,7 @@ from lms.djangoapps.grades.tasks import recalculate_subsection_grade_v3
 from lms.djangoapps.program_enrollments.api import get_external_key_by_user_and_course
 from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.enrollments.api import get_course_enrollment_details
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.forms import to_bool
 from openedx.core.lib.api.view_utils import (
     DeveloperErrorViewMixin,
@@ -526,9 +528,11 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
                 mode, _ = CourseEnrollment.enrollment_mode_for_user(user, str(course.id))
                 return mode == CourseMode.MASTERS
 
-        if is_masters_student():
+        if configuration_helpers.get_value(
+            'ENABLE_FULL_NAME_IN_GRADEBOOK',
+            settings.ENABLE_FULL_NAME_IN_GRADEBOOK,
+        ) or is_masters_student():
             user_entry['full_name'] = user.profile.name
-
         external_user_key = get_external_key_by_user_and_course(user, course.id)
         if external_user_key:
             user_entry['external_user_key'] = external_user_key

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3209,3 +3209,13 @@ SSL_AUTH_DN_FORMAT_STRING = (
 #    Entity ID docs:
 #    https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_SAML_IdP.html#add-and-enable-a-saml-identity-provider
 SAML_IES_ENTITIES_IDS = []
+
+# .. setting_name: ENABLE_FULL_NAME_IN_GRADEBOOK
+# .. setting_implementation: DjangoSetting
+# .. setting_default: False
+# .. setting_description: When True, the full_name field is included in the gradebook API response for all
+#    enrollment modes. When False (default), full_name is only included for students enrolled in the masters
+#    track, preserving the original upstream behavior.
+# .. setting_use_cases: open_edx
+# .. setting_creation_date: 2026-05-28
+ENABLE_FULL_NAME_IN_GRADEBOOK = False


### PR DESCRIPTION
## Description

This pull request updates the Gradebook API response to optionally include the learner's full name in addition to the existing username field.

Currently, the gradebook endpoint primarily exposes the `username` field, which is not particularly useful for instructors when identifying learners. In most instructor-facing workflows, the learner's full name is more meaningful and consistent with the information displayed elsewhere in the platform.

This change introduces a new Django setting:

```python
ENABLE_FULL_NAME_IN_GRADEBOOK = False
```

When enabled, the gradebook API response includes the `full_name` field for all enrollment modes.

When disabled (default behavior), the existing upstream behavior is preserved and `full_name` is only included for learners enrolled in the masters track.

Example endpoint:

```text
/api/grades/v1/gradebook/:courseID/?excluded_course_roles=all&page_size=25
```

Example response:

```json
{
    "user_id": 195898,
    "username": "Nicolas-i6t1",
    "full_name": "Nicolas Example",
    "email": "",
    "percent": 0.0
}
```

### Configuration

New setting:

```python
ENABLE_FULL_NAME_IN_GRADEBOOK = False
```

* `False` (default): preserves the original upstream behavior and only includes `full_name` for masters enrollments.
* `True`: includes `full_name` for all enrollment modes in the gradebook API response.

## Testing instructions

1. Create or access a course with enrolled learners.
2. Ensure the setting is disabled:

```python
ENABLE_FULL_NAME_IN_GRADEBOOK = False
```

3. Call the gradebook endpoint:

```text
/api/grades/v1/gradebook/:courseID/?excluded_course_roles=all&page_size=25
```

4. Verify that:

   * Learners enrolled in the masters track include the `full_name` field.
   * Learners enrolled in other enrollment modes do not include the `full_name` field.

5. Enable the setting:

```python
ENABLE_FULL_NAME_IN_GRADEBOOK = True
```

6. Call the endpoint again.

7. Verify that all learners include the `full_name` field regardless of enrollment mode.


## Other information

No database migrations are required.
