### PR TITLE
feat: make staged static asset size limit configurable by site.

### DIFF
--- a/openedx/core/djangoapps/content_staging/api.py
+++ b/openedx/core/djangoapps/content_staging/api.py
@@ -14,6 +14,7 @@ from opaque_keys.edx.keys import AssetKey, UsageKey, ContainerKey
 from xblock.core import XBlock
 
 from openedx.core.djangoapps.content_tagging.api import TagValuesByObjectIdDict
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.xblock_serializer.api import StaticFile, XBlockSerializer
 from xmodule import block_metadata_utils
 from xmodule.contentstore.content import StaticContent
@@ -139,6 +140,25 @@ def _save_static_assets_to_staged_content(
     Helper method for saving static files into staged content.
     Used by both clipboard and library sync functionality.
     """
+    STATIC_ASSET_STAGING_SIZE_LIMIT_SITE_CONFIG_KEY = "CONTENT_STAGING_STATIC_ASSET_SIZE_LIMIT_BYTES"
+    DEFAULT_STATIC_ASSET_STAGING_SIZE_LIMIT_BYTES = 10 * 1024 * 1024
+
+    static_asset_size_limit = configuration_helpers.get_value(
+        STATIC_ASSET_STAGING_SIZE_LIMIT_SITE_CONFIG_KEY,
+        DEFAULT_STATIC_ASSET_STAGING_SIZE_LIMIT_BYTES,
+    )
+
+    try:
+        static_asset_size_limit = int(static_asset_size_limit)
+    except (TypeError, ValueError):
+        log.warning(
+            "Invalid %s site configuration value: %r. Falling back to %s bytes.",
+            STATIC_ASSET_STAGING_SIZE_LIMIT_SITE_CONFIG_KEY,
+            static_asset_size_limit,
+            DEFAULT_STATIC_ASSET_STAGING_SIZE_LIMIT_BYTES,
+        )
+        static_asset_size_limit = DEFAULT_STATIC_ASSET_STAGING_SIZE_LIMIT_BYTES
+
     for f in static_files:
         source_key = (
             StaticContent.get_asset_key_from_path(usage_key.context_key if usage_key else "", f.url)
@@ -158,11 +178,9 @@ def _save_static_assets_to_staged_content(
         # Compute the md5 hash
         md5_hash = hashlib.md5(content).hexdigest()
 
-        # Because we store clipboard files on S3, uploading really large files will be too slow. And it's wasted if
-        # the copy-paste is just happening within a single course. So for files > 10MB, users must copy the files
-        # manually. In the future we can consider removing this or making it configurable or filterable.
-        limit = 10 * 1024 * 1024
-        if content and len(content) > limit:
+        # Staged files can be stored remotely, so avoid uploading large assets by default.
+        # Site configuration may raise or lower this limit. Oversized files keep their metadata but omit data_file.
+        if content and len(content) > static_asset_size_limit:
             content = None
 
         try:


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3418

## Notes

This integration in currently under discussion in the community upstream, once it will be approved there this change need to be rebased.

**Issue:** https://github.com/openedx/openedx-platform/issues/38672
**PR:** https://github.com/openedx/openedx-platform/pull/38670

## Description

This PR makes the static asset size limit used by content staging configurable through Site Configuration.

Today, static assets larger than 10 MB are not copied into staged content. Instead, the staged file record is still created with metadata such as `source_key_str` and `md5_hash`, but without storing the actual `data_file`. This behavior is useful because staged files may be stored remotely, and uploading large assets can be slow or unnecessary when the asset can still be resolved from the source contentstore.

This change preserves the existing 10 MB default, while allowing operators to override the threshold per site using:

```json
{
  "CONTENT_STAGING_STATIC_ASSET_SIZE_LIMIT_BYTES": 52428800
}
```

The value is expressed in bytes. For example, `52428800` sets the limit to 50 MB.

## Behavior

- If `CONTENT_STAGING_STATIC_ASSET_SIZE_LIMIT_BYTES` is not configured, the existing 10 MB limit is used.
- If the configured value is valid, that value is used as the maximum staged asset size.
- If the configured value is invalid, the code logs a warning and falls back to the default 10 MB limit.
- Assets larger than the configured limit continue to preserve their metadata, but omit `data_file`, matching the current recovery/import behavior.

## Motivation

Some deployments need to support larger static assets during content staging workflows, especially when copying or syncing content that includes larger media or supporting files.

Making the limit configurable through Site Configuration keeps the default behavior unchanged for existing installations, while allowing operators to opt in to a higher or lower threshold without requiring a code change.

## Scope

This PR intentionally keeps the change minimal:

- Adds a Site Configuration lookup for the staged static asset size limit.
- Preserves the existing 10 MB default.
- Keeps the current oversized-asset metadata behavior.
- Adds fallback handling for invalid configuration values.
- Updates the inline comments to describe the configurable behavior.

## Testing Notes

- Verified that the default limit remains 10 MB when no Site Configuration value is present.
- Verified that a custom `CONTENT_STAGING_STATIC_ASSET_SIZE_LIMIT_BYTES` value changes the threshold used when staging static assets.
- Verified that invalid Site Configuration values fall back to the default 10 MB limit.
- Verified that oversized assets still create staged metadata while omitting `data_file`.

## Reviewers

- [x] @MAAngamarca
