### PR TITLE
PADV-3482: render email and username as plain text in CCX grades CSV

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -620,8 +620,8 @@ def ccx_grades_csv(request, course, ccx=None):
                 }
 
                 row_percents = [percents.get(label, 0.0) for label in header]
-                rows.append([student.id, student.email.encode('utf-8'),
-                             student.username.encode('utf-8'),
+                rows.append([student.id, student.email,
+                             student.username,
                              course_grade.percent] + row_percents)
 
         buf = StringIO()


### PR DESCRIPTION
## Description

The CCX Coach grades report (Student Admin tab → Download student grades) was rendering the email and username columns as Python bytes literals — e.g. b'student@example.com' and b'jdoe' — instead of plain text values.

## Root cause

In ccx_grades_csv, each row was built by calling .encode('utf-8') on the email and username:


```
rows.append([student.id, student.email.encode('utf-8'),
             student.username.encode('utf-8'),
             course_grade.percent] + row_percents)
```

In Python 3, .encode('utf-8') returns a bytes object. When csv.writer writes a bytes object to the StringIO buffer, it serializes it using its repr(), which produces the b'...' prefix. This .encode() was a leftover from Python 2 (added to support unicode usernames); after the migration to Python 3 it became unnecessary and incorrect, since csv.writer handles unicode strings natively. The header row and student.id were never encoded, which is why only the email and username columns were affected.

## Fix

Remove the .encode('utf-8') calls so the values are written as plain strings:


```
rows.append([student.id, student.email,
             student.username,
             course_grade.percent] + row_percents)
```

## How to test

- Log in as a CCX Coach and open the CCX Coach dashboard.
- Go to the Student Admin tab and click Download student grades.
- Open the downloaded CSV and confirm the email and username columns show plain values (student@example.com, jdoe) and no longer show the b'...' prefix.