### PR TITLE
chore: preserve CCX course start when saving schedule changes.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -384,9 +384,10 @@ def save_ccx(request, course, ccx=None):  # lint-amnesty, pylint: disable=too-ma
         return earliest, ccx_ids_to_delete
 
     graded = {}
+    course_start_override_id = get_override_for_ccx(ccx, course, 'start_id')
     earliest, ccx_ids_to_delete = override_fields(course, json.loads(request.body.decode('utf8')), graded, [])
     bulk_delete_ccx_override_fields(ccx, ccx_ids_to_delete)
-    if earliest:
+    if earliest and not course_start_override_id:
         override_field_for_ccx(ccx, course, 'start', earliest)
 
     # Attempt to automatically adjust grading policy


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3522

## Description

This PR fixes an issue in the CCX schedule save flow where updating the start date of a section, subsection, or unit could unintentionally overwrite the CCX root course start date.

The `save_ccx` endpoint currently recalculates the earliest start date from the submitted schedule payload and writes it back to the CCX course-level `start` override. As a result, when a CCX already has its own configured start date, saving schedule changes for child blocks can reset the CCX course start based on the master course schedule or the computed earliest content date.

This change preserves the existing CCX course-level start override by only applying the computed earliest start date when the CCX does not already have a course-level start override.

## Technical approach

- Read the existing CCX course-level `start_id` override before applying schedule changes.
- Keep the existing behavior of computing `earliest` from the submitted schedule.
- Only write the computed `earliest` value to the CCX root course `start` field when no CCX course-level start override already exists.

## Reviewers

- [x] @sergivalero20