### PR TITLE
feat: publish CCX course updates after transaction commit.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -16,6 +16,7 @@ from crum import get_current_request
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
+from django.db import transaction
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
@@ -31,6 +32,7 @@ from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.courses import get_course_by_id
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from xmodule.modulestore.django import SignalHandler  # lint-amnesty, pylint: disable=wrong-import-order
 
 from openedx_filters.license_enforcement.filters import (
     CourseLicensingEnabledRequested,
@@ -539,5 +541,64 @@ def multiple_ccx_per_coach(course):
         and configuration_helpers.get_value(
             'ALLOW_MULTIPLE_CCX_PER_COACH',
             False,
+        )
+    )
+
+
+def send_ccx_published_signals(ccx, course_key, is_new_ccx=False):
+    """
+    Emit the CCX publication-related signals and log receiver responses.
+
+    If the CCX has just been created, emit the `COURSE_CREATED` event before
+    sending the legacy `course_published` Django signal. This function performs
+    the actual signal dispatch, so callers that are still inside a database
+    transaction should prefer `publish_signals_after_commit()` to ensure signal
+    receivers only run after the CCX changes have been committed.
+
+    Arguments:
+        ccx: The CCX course object used as the sender of the publish signal.
+        course_key: The course key associated with the CCX.
+        is_new_ccx: Whether the CCX was newly created in the current flow.
+    """
+    if is_new_ccx:
+        # .. event_implemented_name: COURSE_CREATED
+        COURSE_CREATED.send_event(
+            time=datetime.datetime.now(tz=timezone.utc),
+            course=CourseData(
+                course_key=ccx_id,
+            )
+        )
+
+    responses = SignalHandler.course_published.send(
+        sender=ccx,
+        course_key=course_key,
+    )
+    for receiver, response in responses:
+        log.info(
+            'Signal fired when course is published. Receiver: %s. Response: %s',
+            receiver,
+            response,
+        )
+
+
+def publish_signals_after_commit(ccx, course_key, is_new_ccx=False):
+    """
+    Schedule CCX publication-related signals to run after the current transaction commits.
+
+    Defers signal dispatch with `transaction.on_commit()` so downstream receivers
+    observe the committed CCX state, including schedule and grading-policy
+    overrides. If this function is called outside an active transaction, Django
+    executes the callback immediately.
+
+    Arguments:
+        ccx: The CCX course object used as the sender of the publish signal.
+        course_key: The course key associated with the CCX.
+        is_new_ccx: Whether the CCX was newly created in the current flow.
+    """
+    transaction.on_commit(
+        lambda: send_ccx_published_signals(
+            ccx=ccx,
+            course_key=course_key,
+            is_new_ccx=is_new_ccx,
         )
     )

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -54,7 +54,8 @@ from lms.djangoapps.ccx.utils import (
     get_date,
     get_enrollment_action_and_identifiers,
     multiple_ccx_per_coach,
-    parse_date
+    parse_date,
+    publish_signals_after_commit,
 )
 from lms.djangoapps.courseware.field_overrides import disable_overrides
 from lms.djangoapps.grades.api import CourseGradeFactory, is_writable_gradebook_enabled
@@ -64,7 +65,6 @@ from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMI
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import get_course_by_id
-from xmodule.modulestore.django import SignalHandler  # lint-amnesty, pylint: disable=wrong-import-order
 
 log = logging.getLogger(__name__)
 TODAY = datetime.datetime.today  # for patching in tests
@@ -290,28 +290,7 @@ def create_ccx(request, course, ccx=None):
         if not is_course_licensing_enabled:
             add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
-        def publish_ccx():
-            """Send course_published signal for the CCX after the transaction commits and log receiver responses."""
-            responses = SignalHandler.course_published.send(
-                sender=ccx,
-                course_key=ccx_id,
-            )
-            for rec, response in responses:
-                log.info(
-                    'Signal fired when course is published. Receiver: %s. Response: %s',
-                    rec,
-                    response,
-                )
-
-        transaction.on_commit(publish_ccx)
-
-    # .. event_implemented_name: COURSE_CREATED
-    COURSE_CREATED.send_event(
-        time=datetime.datetime.now(tz=timezone.utc),
-        course=CourseData(
-            course_key=ccx_id,
-        )
-    )
+    publish_signals_after_commit(ccx, ccx_id, is_new_ccx=True)
 
     return redirect(url)
 
@@ -384,34 +363,43 @@ def save_ccx(request, course, ccx=None):  # lint-amnesty, pylint: disable=too-ma
         return earliest, ccx_ids_to_delete
 
     graded = {}
-    course_start_override_id = get_override_for_ccx(ccx, course, 'start_id')
-    earliest, ccx_ids_to_delete = override_fields(course, json.loads(request.body.decode('utf8')), graded, [])
-    bulk_delete_ccx_override_fields(ccx, ccx_ids_to_delete)
-    if earliest and not course_start_override_id:
-        override_field_for_ccx(ccx, course, 'start', earliest)
+    schedule_data = json.loads(request.body.decode('utf8'))
+    ccx_key = CCXLocator.from_course_locator(course.id, str(ccx.id))
 
-    # Attempt to automatically adjust grading policy
-    changed = False
-    policy = get_override_for_ccx(
-        ccx, course, 'grading_policy', course.grading_policy
-    )
-    policy = deepcopy(policy)
-    grader = policy['GRADER']
-    for section in grader:
-        count = graded.get(section.get('type'), 0)
-        if count < section.get('min_count', 0):
-            changed = True
-            section['min_count'] = count
-    if changed:
-        override_field_for_ccx(ccx, course, 'grading_policy', policy)
+    with transaction.atomic():
+        course_start_override_id = get_override_for_ccx(ccx, course, 'start_id')
+        earliest, ccx_ids_to_delete = override_fields(
+            course,
+            schedule_data,
+            graded,
+        )
 
-    # using CCX object as sender here.
-    responses = SignalHandler.course_published.send(
-        sender=ccx,
-        course_key=CCXLocator.from_course_locator(course.id, str(ccx.id))
-    )
-    for rec, response in responses:
-        log.info('Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
+        bulk_delete_ccx_override_fields(ccx, ccx_ids_to_delete)
+
+        if earliest and not course_start_override_id:
+            override_field_for_ccx(ccx, course, 'start', earliest)
+
+        # Attempt to automatically adjust grading policy.
+        changed = False
+        policy = get_override_for_ccx(
+            ccx,
+            course,
+            'grading_policy',
+            course.grading_policy,
+        )
+        policy = deepcopy(policy)
+
+        grader = policy['GRADER']
+        for section in grader:
+            count = graded.get(section.get('type'), 0)
+            if count < section.get('min_count', 0):
+                changed = True
+                section['min_count'] = count
+
+        if changed:
+            override_field_for_ccx(ccx, course, 'grading_policy', policy)
+
+    publish_signals_after_commit(ccx, ccx_key, is_new_ccx=False)
 
     return HttpResponse(  # lint-amnesty, pylint: disable=http-response-with-content-type-json, http-response-with-json-dumps
         json.dumps({
@@ -431,20 +419,21 @@ def set_grading_policy(request, course, ccx=None):
     if not ccx:
         raise Http404
 
-    override_field_for_ccx(
-        ccx, course, 'grading_policy', json.loads(request.POST['policy']))
+    ccx_key = CCXLocator.from_course_locator(course.id, str(ccx.id))
 
-    # using CCX object as sender here.
-    responses = SignalHandler.course_published.send(
-        sender=ccx,
-        course_key=CCXLocator.from_course_locator(course.id, str(ccx.id))
-    )
-    for rec, response in responses:
-        log.info('Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
+    with transaction.atomic():
+        override_field_for_ccx(
+            ccx,
+            course,
+            'grading_policy',
+            json.loads(request.POST['policy']),
+        )
+
+    publish_signals_after_commit(ccx, ccx_key, is_new_ccx=False)
 
     url = reverse(
         'ccx_coach_dashboard',
-        kwargs={'course_id': CCXLocator.from_course_locator(course.id, str(ccx.id))}
+        kwargs={'course_id': ccx_key}
     )
     return redirect(url)
 


### PR DESCRIPTION
## Description

This PR updates the CCX publishing flow so `SignalHandler.course_published` is emitted only after the database transaction has been committed.

Previously, some CCX flows triggered the publish signal directly inside the request, while CCX override records could still be part of an active transaction. This created a timing issue where downstream receivers could react to the publish event before the latest CCX changes were safely committed.

To fix this, the PR introduces a shared helper:

`publish_ccx_course_after_commit(ccx, course_key)`

The helper wraps the publish operation with:

`transaction.on_commit(...)`

This ensures that any logic listening to the CCX publish signal runs only after the database state is final and consistent.

## Changes made

- Added a shared post-commit CCX publishing helper.
- Updated the main CCX mutation flows to use the helper:
  - `create_ccx`
  - `save_ccx`
  - `set_grading_policy`
- Removed duplicated inline publish-signal logic from the views.
- Preserved the existing `course_published` signal behavior, but moved its execution to the post-commit phase.

## Why this is needed

CCX schedule and grading policy updates are persisted through database-backed override records. Publishing during the request can allow signal receivers to execute before those records are fully committed.

By using `transaction.on_commit`, we guarantee that the publish signal is only emitted after the CCX changes are actually available to the rest of the platform.

## How to test

Manual validation:

1. Create a CCX.
2. Update CCX schedule data.
3. Update the CCX grading policy.
4. Confirm the coach dashboard reflects the saved changes.
5. Confirm the publish-related behavior still runs after each mutation.
6. Confirm no publish signal is fired before the transaction commits.

## Reviewers

- [x] @MAAngamarca
- [x] @Squirrel18