### PR TITLE
fix: hot fix for COURSE_CREATED signal in create_ccx.

### DIFF
--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -9,6 +9,7 @@ import datetime
 import logging
 from contextlib import contextmanager
 from smtplib import SMTPException
+from functools import partial
 
 import pytz
 from ccx_keys.locator import CCXLocator
@@ -545,30 +546,18 @@ def multiple_ccx_per_coach(course):
     )
 
 
-def send_ccx_published_signals(ccx, course_key, is_new_ccx=False):
+def send_ccx_published_signal(ccx, course_key):
     """
-    Emit the CCX publication-related signals and log receiver responses.
+    Emit the CCX publication-related signal and log receiver responses.
 
-    If the CCX has just been created, emit the `COURSE_CREATED` event before
-    sending the legacy `course_published` Django signal. This function performs
-    the actual signal dispatch, so callers that are still inside a database
-    transaction should prefer `publish_signals_after_commit()` to ensure signal
-    receivers only run after the CCX changes have been committed.
+    This function performs the actual signal dispatch, so callers that are still
+    inside a database transaction should prefer `publish_signals_after_commit()`
+    to ensure signal receivers only run after the CCX changes have been committed.
 
     Arguments:
         ccx: The CCX course object used as the sender of the publish signal.
         course_key: The course key associated with the CCX.
-        is_new_ccx: Whether the CCX was newly created in the current flow.
     """
-    if is_new_ccx:
-        # .. event_implemented_name: COURSE_CREATED
-        COURSE_CREATED.send_event(
-            time=datetime.datetime.now(tz=timezone.utc),
-            course=CourseData(
-                course_key=ccx_id,
-            )
-        )
-
     responses = SignalHandler.course_published.send(
         sender=ccx,
         course_key=course_key,
@@ -581,7 +570,7 @@ def send_ccx_published_signals(ccx, course_key, is_new_ccx=False):
         )
 
 
-def publish_signals_after_commit(ccx, course_key, is_new_ccx=False):
+def publish_signals_after_commit(ccx, course_key):
     """
     Schedule CCX publication-related signals to run after the current transaction commits.
 
@@ -596,9 +585,9 @@ def publish_signals_after_commit(ccx, course_key, is_new_ccx=False):
         is_new_ccx: Whether the CCX was newly created in the current flow.
     """
     transaction.on_commit(
-        lambda: send_ccx_published_signals(
+        partial(
+            send_ccx_published_signal,
             ccx=ccx,
             course_key=course_key,
-            is_new_ccx=is_new_ccx,
         )
     )

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -290,7 +290,15 @@ def create_ccx(request, course, ccx=None):
         if not is_course_licensing_enabled:
             add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
 
-    publish_signals_after_commit(ccx, ccx_id, is_new_ccx=True)
+        publish_signals_after_commit(ccx=ccx, course_key=ccx_id)
+
+    # .. event_implemented_name: COURSE_CREATED
+    COURSE_CREATED.send_event(
+        time=datetime.datetime.now(tz=timezone.utc),
+        course=CourseData(
+            course_key=ccx_id,
+        )
+    )
 
     return redirect(url)
 
@@ -399,7 +407,7 @@ def save_ccx(request, course, ccx=None):  # lint-amnesty, pylint: disable=too-ma
         if changed:
             override_field_for_ccx(ccx, course, 'grading_policy', policy)
 
-    publish_signals_after_commit(ccx, ccx_key, is_new_ccx=False)
+        publish_signals_after_commit(ccx=ccx, course_key=ccx_key)
 
     return HttpResponse(  # lint-amnesty, pylint: disable=http-response-with-content-type-json, http-response-with-json-dumps
         json.dumps({
@@ -429,7 +437,7 @@ def set_grading_policy(request, course, ccx=None):
             json.loads(request.POST['policy']),
         )
 
-    publish_signals_after_commit(ccx, ccx_key, is_new_ccx=False)
+        publish_signals_after_commit(ccx=ccx, course_key=ccx_key)
 
     url = reverse(
         'ccx_coach_dashboard',


### PR DESCRIPTION
## Description

Updates the CCX creation signal flow to keep the generic publish utility focused only on the course_published signal, while emitting COURSE_CREATED explicitly from the create_ccx flow.

This preserves the expected ordering between CCX publishing, CourseOverview refresh, and the downstream Course Operations creation event, avoiding mixed async/sync signal behavior inside the shared CCX utility.

## Changes Made
- [x] Removed the is_new_ccx argument from publish_signals_after_commit().
- [x] Renamed the publish helper back to singular send_ccx_published_signal().
- [x] Removed COURSE_CREATED handling from the generic CCX publish utility.
- [x] Added explicit COURSE_CREATED.send_event() handling in create_ccx.
- [x] Updated create_ccx, save_ccx, and set_grading_policy to call publish_signals_after_commit() with the simplified signature.

## Testing
- Created a CCX successfully.
- Verified the CCX publish signal is still triggered after creation.
- Verified COURSE_CREATED is emitted from the CCX creation flow.
- Confirmed existing CCX save and grading-policy update flows still call the publish signal successfully.

## Reviewers
- [x] @MAAngamarca
- [x] @Squirrel18 